### PR TITLE
Fix code block cleaning

### DIFF
--- a/llm_interface.py
+++ b/llm_interface.py
@@ -533,9 +533,7 @@ class LLMService:
         if len(cleaned_text) < len(text_before_think_removal): 
             logger.debug(f"clean_model_response: Removed content associated with <think>/similar tags. Length before: {len(text_before_think_removal)}, after: {len(cleaned_text)}.")
 
-        cleaned_text = re.sub(r'```(?:[a-zA-Z0-9]+)?\s*.*?\s*```', '', cleaned_text, flags=re.DOTALL | re.IGNORECASE)
-        cleaned_text = re.sub(r'^```\s*\n', '', cleaned_text, flags=re.MULTILINE) 
-        cleaned_text = re.sub(r'\n\s*```$', '', cleaned_text, flags=re.MULTILINE)
+        cleaned_text = re.sub(r"```(?:[a-zA-Z0-9_-]+)?\s*(.*?)\s*```", r"\1", cleaned_text, flags=re.DOTALL)
 
         cleaned_text = re.sub(r'^\s*Chapter \d+\s*[:\-—]?\s*(.*?)\s*$', r'\1', cleaned_text, flags=re.MULTILINE | re.IGNORECASE).strip()
         


### PR DESCRIPTION
## Summary
- unwrap triple backtick blocks instead of discarding them in `clean_model_response`

## Testing
- `python -m py_compile llm_interface.py kg_maintainer_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_683f8a14525c832f8c4f98d8bbb62774