### PR TITLE
Fix code block cleaning

### DIFF
--- a/llm_interface.py
+++ b/llm_interface.py
@@ -533,9 +533,7 @@ class LLMService:
         if len(cleaned_text) < len(text_before_think_removal): 
             logger.debug(f"clean_model_response: Removed content associated with <think>/similar tags. Length before: {len(text_before_think_removal)}, after: {len(cleaned_text)}.")
 
-        cleaned_text = re.sub(r'```(?:[a-zA-Z0-9]+)?\s*.*?\s*```', '', cleaned_text, flags=re.DOTALL | re.IGNORECASE)
-        cleaned_text = re.sub(r'^```\s*\n', '', cleaned_text, flags=re.MULTILINE) 
-        cleaned_text = re.sub(r'\n\s*```$', '', cleaned_text, flags=re.MULTILINE)
+        cleaned_text = re.sub(r"```(?:[a-zA-Z0-9_-]+)?\s*(.*?)\s*```", r"\1", cleaned_text, flags=re.DOTALL)
 
         cleaned_text = re.sub(r'^\s*Chapter \d+\s*[:\-—]?\s*(.*?)\s*$', r'\1', cleaned_text, flags=re.MULTILINE | re.IGNORECASE).strip()
         

--- a/parsing_utils.py
+++ b/parsing_utils.py
@@ -158,8 +158,8 @@ _HIERARCHICAL_STRICT_WORLD_CATEGORIES = ["Overview", "Locations", "Factions", "S
 _COMPILED_CATEGORY_ALTERNATION = "|".join(cat for cat in _HIERARCHICAL_STRICT_WORLD_CATEGORIES)
 
 WORLD_CATEGORY_HEADER_PATTERN = re.compile(
-   r"^\s*(?:Category\s*:\s*)?(?:\*\*)?(" + _COMPILED_CATEGORY_ALTERNATION + r")(?:\*\*)?\s*:\s*$",
-   re.IGNORECASE | re.MULTILINE | re.UNICODE 
+   r"^\s*(?:Category\s*:\s*)?(?:\*\*)?(" + _COMPILED_CATEGORY_ALTERNATION + r")(?:\*\*)?\s*:?\s*$",
+   re.IGNORECASE | re.MULTILINE | re.UNICODE
 )
 
 # Potential simplified pattern for testing if the main one mysteriously fails
@@ -170,10 +170,10 @@ SIMPLER_WORLD_CATEGORY_HEADER_PATTERN = re.compile(
 )
 
 WORLD_ITEM_HEADER_PATTERN = re.compile(
-    r"^\s*(?:\*\*)?([A-Za-z0-9\s_()'.\"\-]+?)(?:\*\*)?:\s*(.*)$"
+    r"^\s*(?:Item\s*:\s*)?(?:\*\*)?([A-Za-z0-9\s_()'.\"\-]+?)(?:\*\*)?\s*:?\s*(.*)$"
 )
 WORLD_ITEM_HEADER_PATTERN_NO_COLON_EOL = re.compile(
-    r"^\s*(?:\*\*)?([A-Za-z0-9\s_()'.\"\-]+?)(?:\*\*)?(?::\s*)?$"
+    r"^\s*(?:Item\s*:\s*)?(?:\*\*)?([A-Za-z0-9\s_()'.\"\-]+?)(?:\*\*)?\s*:?\s*$"
 )
 
 def parse_hierarchical_structured_text(


### PR DESCRIPTION
## Summary
- unwrap triple backtick blocks instead of discarding them in `clean_model_response`
- allow world update categories without trailing colon and parse `Item:` headers

## Testing
- `python -m py_compile llm_interface.py kg_maintainer_agent.py parsing_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_683f8a14525c832f8c4f98d8bbb62774