### PR TITLE
I've addressed an issue where the system was sometimes generating war…

### DIFF
--- a/tests/test_initial_setup_logic.py
+++ b/tests/test_initial_setup_logic.py
@@ -285,3 +285,125 @@ async def test_existing_user_data_preserved_and_llm_fills_gaps(agent_instance):
     # is_default and user_supplied_data flags should be removed after processing
     assert "is_default" not in wb
     assert "user_supplied_data" not in wb
+
+
+@pytest.mark.asyncio
+async def test_generate_world_building_mixed_llm_output_format(agent_instance):
+    """
+    Tests generate_world_building_logic with LLM JSON output that has:
+    - A category ('lore') containing both proper items (name: {details_dict})
+    - And flat key-value pairs (e.g., "Overall Vibe": "string_value", "Key Elements": ["list_value"])
+      which should be collected into a default item named after the category ('lore').
+    - Also tests wrapping of non-list key values (string -> {"text": val}, list -> {"items": val}).
+    """
+    agent_instance.plot_outline = {'title': 'Test Novel', 'genre': 'Fantasy', 'setting_description': 'A world of tests'}
+    agent_instance.world_building = {} # Start fresh
+
+    llm_json_output = """
+    {
+      "lore": {
+        "Overall Vibe": "A mix of ancient tales and forgotten songs.",
+        "Key Elements": ["Ancient Scrolls", "Whispering Winds"],
+        "The Sunken Library": {
+          "description": "A library lost to the depths, holding ancient secrets.",
+          "atmosphere": "Mysterious and silent"
+        },
+        "Dragon's Peak": {
+          "description": "A mountain where dragons once roosted.",
+          "traits": ["Majestic", "Dangerous"]
+        },
+        "NonListPropertyForDefault": ["This", "should", "be", "wrapped"],
+        "Unnormalized Default Prop": "This key should be normalized and value wrapped"
+      }
+    }
+    """
+    mock_llm_return = (llm_json_output, {'prompt_tokens': 10, 'completion_tokens': 10, 'total_tokens': 20})
+
+    # Ensure 'key_elements' and 'traits' are treated as list keys for this test.
+    # And that 'overall_vibe' and 'non_list_property_for_default' are NOT list keys.
+    # 'unnormalized_default_prop' should also not be a list key.
+    # Assuming WORLD_DETAIL_KEY_MAP_FROM_MARKDOWN_TO_INTERNAL maps:
+    # "overall_vibe" -> "overall_vibe" (or similar, if it needs normalization)
+    # "key_elements" -> "key_elements"
+    # "traits" -> "traits"
+    # "non_list_property_for_default" -> "non_list_property_for_default"
+    # "Unnormalized Default Prop" -> "unnormalized_default_prop" (after auto-normalization by JSON loader if it happens, or by our mapping)
+    # For the purpose of this test, let's ensure the internal keys are what we expect after mapping.
+    # The critical part is how WORLD_DETAIL_LIST_INTERNAL_KEYS is set up.
+
+    # Original list keys from the module
+    original_list_keys = list(WORLD_DETAIL_LIST_INTERNAL_KEYS)
+
+    # Keys we want to ensure are treated as list keys for the test
+    # (assuming their internal representation after mapping is straightforward)
+    test_specific_list_keys = ["key_elements", "traits"]
+
+    # Keys that should NOT be list keys for the default item's properties, so they get wrapped
+    # (assuming their internal representation after mapping)
+    # "overall_vibe", "non_list_property_for_default", "unnormalized_default_prop"
+
+    # Create a combined list for patching, ensuring no duplicates and preserving originals
+    mock_list_keys_content = list(set(original_list_keys + test_specific_list_keys))
+
+    # Patch the global list within the 'initial_setup_logic' module for the duration of this test
+    with patch('initial_setup_logic.llm_service.async_call_llm', AsyncMock(return_value=mock_llm_return)), \
+         patch('initial_setup_logic.WORLD_DETAIL_LIST_INTERNAL_KEYS', mock_list_keys_content):
+
+        # Max diff for pytest is usually not needed like unittest's self.maxDiff = None
+        # Pytest's diffing is generally quite good by default.
+        await generate_world_building_logic(agent_instance)
+
+    assert 'lore' in agent_instance.world_building
+    lore_category_data = agent_instance.world_building['lore']
+
+    # --- Default Item Asserts (named 'lore') ---
+    assert 'lore' in lore_category_data, "Default item named after category 'lore' should exist."
+    default_item = lore_category_data['lore']
+
+    # 'Overall Vibe' is not in WORLD_DETAIL_LIST_INTERNAL_KEYS, so its string value should be wrapped.
+    # Assuming 'Overall Vibe' normalizes to 'overall_vibe' or is used as is if not in WORLD_DETAIL_KEY_MAP_FROM_MARKDOWN_TO_INTERNAL
+    # The current implementation uses the JSON key directly if not in WORLD_DETAIL_KEY_MAP_FROM_MARKDOWN_TO_INTERNAL.
+    # Let's assume it becomes "overall_vibe" after internal mapping if such a mapping exists, or "Overall Vibe" if not.
+    # For the test, we'll check for the key as it would appear *after* potential mapping in `default_item_properties`.
+    # The key `internal_item_key_for_agent` is used.
+    # If "Overall Vibe" is not in WORLD_DETAIL_KEY_MAP_FROM_MARKDOWN_TO_INTERNAL, it will be "Overall Vibe".
+    # If it is, e.g. {"overall_vibe_llm": "overall_vibe_internal"}, then we check for "overall_vibe_internal".
+    # Let's assume no specific mapping for "Overall Vibe" for simplicity of this test's setup.
+    # The logic is: internal_item_key_for_agent = WORLD_DETAIL_KEY_MAP_FROM_MARKDOWN_TO_INTERNAL.get(item_key_from_llm, item_key_from_llm)
+
+    # The key "Overall Vibe" is not in WORLD_DETAIL_KEY_MAP_FROM_MARKDOWN_TO_INTERNAL, so internal_item_key_for_agent = "Overall Vibe"
+    # And "Overall Vibe" is not in mock_list_keys_content. So it should be wrapped.
+    assert default_item.get('Overall Vibe') == {'text': 'A mix of ancient tales and forgotten songs.'}
+
+    # 'Key Elements' is in mock_list_keys_content, so its list value should NOT be wrapped.
+    # Assuming "Key Elements" maps to "key_elements" or is used as is.
+    # The key "Key Elements" is not in WORLD_DETAIL_KEY_MAP_FROM_MARKDOWN_TO_INTERNAL, internal_item_key_for_agent = "Key Elements"
+    # "Key Elements" IS in mock_list_keys_content (due to test_specific_list_keys). So, not wrapped.
+    assert default_item.get('Key Elements') == ['Ancient Scrolls', 'Whispering Winds']
+
+    # 'NonListPropertyForDefault' is NOT in mock_list_keys_content, so its list value should be wrapped.
+    # internal_item_key_for_agent = "NonListPropertyForDefault"
+    assert default_item.get('NonListPropertyForDefault') == {'items': ["This", "should", "be", "wrapped"]}
+
+    # 'Unnormalized Default Prop' -> internal: 'unnormalized_default_prop' (if mapped) or 'Unnormalized Default Prop' (if not)
+    # Let's assume it's not mapped for simplicity. So internal key is 'Unnormalized Default Prop'.
+    # This key is not in mock_list_keys_content. So its string value should be wrapped.
+    assert default_item.get('Unnormalized Default Prop') == {'text': "This key should be normalized and value wrapped"}
+
+
+    # --- Proper Item Asserts ("The Sunken Library") ---
+    assert 'The Sunken Library' in lore_category_data
+    sunken_library = lore_category_data['The Sunken Library']
+    # 'description' is not in WORLD_DETAIL_LIST_INTERNAL_KEYS (by default, unless added to original_list_keys)
+    # Assuming default 'description' is not a list key.
+    assert sunken_library.get('description') == {'text': 'A library lost to the depths, holding ancient secrets.'}
+    # 'atmosphere' is not in WORLD_DETAIL_LIST_INTERNAL_KEYS
+    assert sunken_library.get('atmosphere') == {'text': 'Mysterious and silent'}
+
+    # --- Proper Item Asserts ("Dragon's Peak") ---
+    assert "Dragon's Peak" in lore_category_data
+    dragons_peak = lore_category_data["Dragon's Peak"]
+    # 'description' not a list key
+    assert dragons_peak.get('description') == {'text': 'A mountain where dragons once roosted.'}
+    # 'traits' IS in mock_list_keys_content. So, not wrapped.
+    assert dragons_peak.get('traits') == ['Majestic', 'Dangerous']


### PR DESCRIPTION
…nings during the initial world-building process. This happened when the language model provided details for world-building items in an unexpected format – occasionally as a simple string or list, instead of the dictionary structure it was anticipating.

For instance, a category like "society" might have incorrectly produced an entry like `"description": "Actual society description..."` instead of the expected `"Society Overview": {"description": "Actual society description..."}`.

To fix this, I've updated `initial_setup_logic.py` to handle these kinds of responses more effectively:
- If a category in the language model's output contains direct key-value pairs where the value isn't a dictionary (like "description": "text"), these are now grouped into a 'default' item for that category. This default item usually takes the name of the category itself.
- String values for attributes that aren't meant to be lists are now wrapped into a `{"text": "value"}` dictionary.
- List values for attributes that aren't meant to be lists are now wrapped into an `{"items": ["value"]}` dictionary.
- This ensures that other parts of the system always receive a dictionary for item details, which prevents the warnings.

I've also added a new unit test in `tests/test_initial_setup_logic.py` to confirm this improved parsing logic handles mixed-format responses correctly. No changes were needed in `kg_maintainer/parsing.py` because the problem was resolved by correcting the data structure at the initial parsing stage.