### PR TITLE
Remove stray markdown delimiter

### DIFF
--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -141,4 +141,3 @@ def test_parse_world_updates_empty_or_invalid_json():
 # - Handling of completely unexpected structures in the JSON from LLM
 # - Test for the default elaboration notes more thoroughly.
 
-```


### PR DESCRIPTION
## Summary
- delete leftover backtick at end of `tests/test_parsing.py`

## Testing
- `python3 -m py_compile tests/test_parsing.py`
- `PYTHONPATH=$(pwd) pytest -q` *(fails: test suite has existing failures)*

------
https://chatgpt.com/codex/tasks/task_e_68413bfa090c832f8b81f23401c35fad