### PR TITLE
style(agents): format chapter drafting logic

### DIFF
--- a/chapter_drafting_logic.py
+++ b/chapter_drafting_logic.py
@@ -62,7 +62,9 @@ async def generate_chapter_draft_logic(
             max_plan_tokens_for_prompt = config.MAX_CONTEXT_TOKENS // 3
             plan_section_for_prompt_parts.append(
                 _format_scene_plan_for_prompt(
-                    chapter_plan, config.DRAFTING_MODEL, max_plan_tokens_for_prompt
+                    chapter_plan,
+                    config.DRAFTING_MODEL,
+                    max_plan_tokens_for_prompt,
                 )
             )
             logger.info(
@@ -90,8 +92,11 @@ async def generate_chapter_draft_logic(
             agent, chapter_number - 1
         )
     )
-    world_building_plain_text = await get_filtered_world_data_for_prompt_plain_text(
-        agent, chapter_number - 1
+    world_building_plain_text = (
+        await get_filtered_world_data_for_prompt_plain_text(
+            agent,
+            chapter_number - 1,
+        )
     )
 
     plot_outline_data = getattr(
@@ -114,7 +119,10 @@ async def generate_chapter_draft_logic(
             "**Story Bible / Core Information:**",
             f"  - Genre: {plot_outline_data.get('genre', 'N/A')}",
             f"  - Central Theme: {plot_outline_data.get('theme', 'N/A')}",
-            (f"  - Protagonist: {plot_outline_data.get('protagonist_name', 'N/A')}"),
+            (
+                "  - Protagonist: "
+                f"{plot_outline_data.get('protagonist_name', 'N/A')}"
+            ),
             (
                 "  - Protagonist's Character Arc: "
                 f"{plot_outline_data.get('character_arc', 'N/A')}"
@@ -130,7 +138,8 @@ async def generate_chapter_draft_logic(
             world_building_plain_text
             if world_building_plain_text.strip()
             else (
-                "No specific world building notes provided for this chapter's context."
+                "No specific world building notes provided for this "
+                "chapter's context."
             ),
             "```",
             (
@@ -141,10 +150,14 @@ async def generate_chapter_draft_logic(
             char_profiles_plain_text
             if char_profiles_plain_text.strip()
             else (
-                "No specific character profiles provided for this chapter's context."
+                "No specific character profiles provided for this "
+                "chapter's context."
             ),
             "```",
-            ("**Hybrid Context (Semantic Context for Flow & KG Facts for Canon):**"),
+            (
+                "**Hybrid Context (Semantic Context for Flow & KG Facts "
+                "for Canon):**"
+            ),
             "--- BEGIN HYBRID CONTEXT ---",
             hybrid_context
             if hybrid_context.strip()
@@ -248,7 +261,9 @@ async def generate_chapter_draft_logic(
         )
         return None, None
 
-    cleaned_text = llm_service.clean_model_response(raw_llm_text_for_log)  # MODIFIED
+    cleaned_text = llm_service.clean_model_response(
+        raw_llm_text_for_log
+    )  # MODIFIED
 
     if not cleaned_text or len(cleaned_text) < 50:
         logger.error(


### PR DESCRIPTION
## Summary
- break up long strings in chapter_drafting_logic
- split long parameter lists onto multiple lines

## Testing
- `ruff check chapter_drafting_logic.py --fix`
- `pytest tests -v` *(fails: test_agent_extract.py, test_cypher_generation.py, test_parsing.py, test_parsing_utils.py)*
- `mypy .` *(fails: found 31 errors in 12 files)*

------
https://chatgpt.com/codex/tasks/task_e_68421c8c5938832faa977746fe3f2aff