### PR TITLE
style(memory): clean kg_maintainer

### DIFF
--- a/kg_maintainer/__init__.py
+++ b/kg_maintainer/__init__.py
@@ -1,7 +1,10 @@
 """Package consolidating KG maintainer utilities."""
 
 from .models import CharacterProfile, WorldItem
-from .parsing import parse_unified_character_updates, parse_unified_world_updates
+from .parsing import (
+    parse_unified_character_updates,
+    parse_unified_world_updates,
+)
 from .merge import (
     merge_character_profile_updates,
     merge_world_item_updates,

--- a/kg_maintainer/merge.py
+++ b/kg_maintainer/merge.py
@@ -18,17 +18,25 @@ def initialize_new_character_profile(
     new_profile = CharacterProfile(
         name=char_name,
         description=data.get(
-            "description", f"A character newly introduced in Chapter {chapter_number}."
+            "description",
+            f"A character newly introduced in Chapter {chapter_number}.",
         ),
         traits=sorted(
-            {t for t in data.get("traits", []) if isinstance(t, str) and t.strip()}
+            {
+                t
+                for t in data.get("traits", [])
+                if isinstance(t, str) and t.strip()
+            }
         ),
         relationships=data.get("relationships", {}),
         status=data.get("status", "Newly introduced"),
         updates={
             dev_key: data.get(
                 dev_key,
-                f"Character '{char_name}' introduced in Chapter {chapter_number}.",
+                (
+                    f"Character '{char_name}' introduced in "
+                    f"Chapter {chapter_number}."
+                ),
             )
         },
     )
@@ -59,8 +67,8 @@ def merge_character_profile_updates(
         prof_dict = profile.to_dict()
         modified = False
         for key, val in data.items():
-            if key in {"modification_proposal", provisional_key} or key.startswith(
-                "development_in_chapter_"
+            if key in {"modification_proposal", provisional_key} or (
+                key.startswith("development_in_chapter_")
             ):
                 continue
             if key == "traits" and isinstance(val, list):
@@ -77,14 +85,20 @@ def merge_character_profile_updates(
                     if profile.relationships.get(target) != rel:
                         profile.relationships[target] = rel
                         modified = True
-            elif isinstance(val, str) and val.strip() and prof_dict.get(key) != val:
+            elif (
+                isinstance(val, str)
+                and val.strip()
+                and prof_dict.get(key) != val
+            ):
                 profile.updates[key] = val
                 modified = True
         if dev_key in data and isinstance(data[dev_key], str):
             profile.updates[dev_key] = data[dev_key]
             modified = True
         if from_flawed_draft:
-            profile.updates[provisional_key] = "provisional_from_unrevised_draft"
+            profile.updates[provisional_key] = (
+                "provisional_from_unrevised_draft"
+            )
         if modified:
             logger.debug("Profile for %s modified", name)
 
@@ -113,11 +127,13 @@ def merge_world_item_updates(
             item = world[category][name]
             item_props = item.to_dict()
             for key, val in data.items():
-                if key in {provisional_key, "modification_proposal"} or key.startswith(
-                    (
-                        "updated_in_chapter_",
-                        "added_in_chapter_",
-                        "source_quality_chapter_",
+                if key in {provisional_key, "modification_proposal"} or (
+                    key.startswith(
+                        (
+                            "updated_in_chapter_",
+                            "added_in_chapter_",
+                            "source_quality_chapter_",
+                        )
                     )
                 ):
                     if (
@@ -142,4 +158,7 @@ def merge_world_item_updates(
                     item.properties[key] = sub
                 elif cur_val != val:
                     item.properties[key] = val
-            item.properties.setdefault(f"updated_in_chapter_{chapter_number}", True)
+            item.properties.setdefault(
+                f"updated_in_chapter_{chapter_number}",
+                True,
+            )

--- a/kg_maintainer/models.py
+++ b/kg_maintainer/models.py
@@ -10,13 +10,17 @@ from kg_constants import (
 
 
 def _normalize_for_id(text: str) -> str:
-    """Normalizes a string for use in an ID (lowercase, spaces to underscores, remove problematic chars)."""
+    """Normalize a string for use in an ID."""
+    """Lowercase, convert spaces to underscores, remove problematic chars."""
     if not isinstance(text, str):  # Handle potential non-string input
         text = str(text)
     text = text.strip().lower()
-    text = re.sub(r"['\"()]", "", text)  # Remove apostrophes, quotes, parentheses
-    text = re.sub(r"\s+", "_", text)  # Replace whitespace with underscore
-    text = re.sub(r"[^a-z0-9_]", "", text)  # Keep only alphanumeric and underscore
+    text = re.sub(r"['\"()]", "", text)
+    # Remove apostrophes, quotes, parentheses
+    text = re.sub(r"\s+", "_", text)
+    # Replace whitespace with underscore
+    text = re.sub(r"[^a-z0-9_]", "", text)
+    # Keep only alphanumeric and underscore
     return text
 
 
@@ -67,22 +71,31 @@ class WorldItem:
     properties: Dict[str, Any] = field(default_factory=dict)
 
     @classmethod
-    def from_dict(cls, category: str, name: str, data: Dict[str, Any]) -> "WorldItem":
+    def from_dict(
+        cls, category: str, name: str, data: Dict[str, Any]
+    ) -> "WorldItem":
         """
         Creates a WorldItem.
         'category' and 'name' are the intended display/canonical values.
-        The 'id' is always generated deterministically from normalized versions of these.
+        The 'id' is always generated deterministically from normalized
+        versions of these.
         Any 'id' in the 'data' dict is ignored.
         """
-        if not category or not isinstance(category, str) or not category.strip():
+        if (
+            not category
+            or not isinstance(category, str)
+            or not category.strip()
+        ):
             raise ValueError("WorldItem category must be a non-empty string.")
         if not name or not isinstance(name, str) or not name.strip():
             raise ValueError(
-                f"WorldItem name must be a non-empty string (for category '{category}')."
+                "WorldItem name must be a non-empty string "
+                f"(for category '{category}')."
             )
 
         # Generate canonical ID from normalized category and name.
-        # The 'name' and 'category' stored on the instance are the ones passed as arguments.
+        # The 'name' and 'category' stored on the instance are the ones
+        # passed as arguments.
         normalized_id_category = _normalize_for_id(category)
         normalized_id_name = _normalize_for_id(name)
 
@@ -104,7 +117,14 @@ class WorldItem:
             if k not in {"id", KG_NODE_CREATED_CHAPTER, KG_IS_PROVISIONAL}
         }
 
-        return cls(item_id, category, name, created_chapter, is_provisional, props)
+        return cls(
+            item_id,
+            category,
+            name,
+            created_chapter,
+            is_provisional,
+            props,
+        )
 
     def to_dict(self) -> Dict[str, Any]:
         data = {
@@ -113,7 +133,8 @@ class WorldItem:
             KG_IS_PROVISIONAL: self.is_provisional,
             "created_chapter": self.created_chapter,  # convenience duplicate
             "is_provisional": self.is_provisional,  # convenience duplicate
-            # name and category are top-level attributes, not in properties dict for this method's output
+            # name and category are top-level attributes, not in properties
+            # dict for this method's output
         }
         data.update(self.properties)
         return data


### PR DESCRIPTION
## Summary
- tidy up imports and break long lines in KG maintainer
- remove trailing whitespace throughout KG maintainer modules
- fix indentation in parsing utilities

## Testing
- `ruff check kg_maintainer --fix`
- `ruff check . && ruff format --check .` *(fails: unused imports and formatting issues)*
- `pytest tests -v` *(fails: 7 failed, 26 passed, 10 skipped)*
- `mypy .` *(fails: found 31 errors in 12 files)*

------
https://chatgpt.com/codex/tasks/task_e_684221fb3a3c832fa58f5d11e41674b0