### PR TITLE
test: clean test style issues

### DIFF
--- a/tests/test_agent_extract.py
+++ b/tests/test_agent_extract.py
@@ -21,7 +21,9 @@ def test_extract_and_merge(monkeypatch):
         "_llm_extract_updates",
         lambda props, text, num: llm_service_mock.async_call_llm(),
     )
-    monkeypatch.setattr(agent, "persist_profiles", lambda profiles: asyncio.sleep(0))
+    monkeypatch.setattr(
+        agent, "persist_profiles", lambda profiles: asyncio.sleep(0)
+    )
     monkeypatch.setattr(agent, "persist_world", lambda world: asyncio.sleep(0))
     monkeypatch.setattr(
         "data_access.kg_queries.add_kg_triples_batch_to_db",

--- a/tests/test_character_labeling.py
+++ b/tests/test_character_labeling.py
@@ -1,5 +1,5 @@
 import pytest
-from typing import List, Dict, Any, Tuple, Optional
+from typing import List, Dict, Any, Tuple
 from unittest.mock import AsyncMock, patch
 
 # Assuming data_access.kg_queries is the path. Adjust if necessary based on project structure.
@@ -19,12 +19,18 @@ from kg_constants import KG_REL_CHAPTER_ADDED, KG_IS_PROVISIONAL
     "entity_type, expected_labels",
     [
         ("Character", ":Character:Entity"),
-        ("character", ":Character:Entity"),  # Test case-insensitivity for "Character"
+        (
+            "character",
+            ":Character:Entity",
+        ),  # Test case-insensitivity for "Character"
         (
             "Person",
             ":Character:Person:Entity",
         ),  # Person should get Character first, then Person
-        ("person", ":Character:Person:Entity"),  # Test case-insensitivity for "Person"
+        (
+            "person",
+            ":Character:Person:Entity",
+        ),  # Test case-insensitivity for "Person"
         ("Location", ":Location:Entity"),
         ("Event", ":Event:Entity"),
         ("  Item ", ":Item:Entity"),  # Test stripping whitespace
@@ -68,7 +74,9 @@ def mock_neo4j_manager():
 captured_statements_for_tests: List[Tuple[str, Dict[str, Any]]] = []
 
 
-async def capture_statements_mock(statements: List[Tuple[str, Dict[str, Any]]]):
+async def capture_statements_mock(
+    statements: List[Tuple[str, Dict[str, Any]]],
+):
     captured_statements_for_tests.clear()
     captured_statements_for_tests.extend(statements)
     return None
@@ -134,8 +142,10 @@ async def test_add_entities_with_character_labeling(mock_neo4j_manager):
     for query, params in captured_statements_for_tests:
         if params.get("subject_name_param") == "Alice":
             assert (
-                "MERGE (s:Character:Entity {name: $subject_name_param})" in query
-                or "MERGE (s:Character:Entity {name: $subject_name_param})" in query
+                "MERGE (s:Character:Entity {name: $subject_name_param})"
+                in query
+                or "MERGE (s:Character:Entity {name: $subject_name_param})"
+                in query
             )  # Accommodate slight variations if any
             alice_statement_found = True
             break
@@ -148,7 +158,8 @@ async def test_add_entities_with_character_labeling(mock_neo4j_manager):
     for query, params in captured_statements_for_tests:
         if params.get("subject_name_param") == "Bob":
             assert (
-                "MERGE (s:Character:Person:Entity {name: $subject_name_param})" in query
+                "MERGE (s:Character:Person:Entity {name: $subject_name_param})"
+                in query
                 or "MERGE (s:Character:Person:Entity {name: $subject_name_param})"
                 in query
             )
@@ -162,7 +173,10 @@ async def test_add_entities_with_character_labeling(mock_neo4j_manager):
     castle_statement_found = False
     for query, params in captured_statements_for_tests:
         if params.get("subject_name_param") == "Castle":
-            assert "MERGE (s:Location:Entity {name: $subject_name_param})" in query
+            assert (
+                "MERGE (s:Location:Entity {name: $subject_name_param})"
+                in query
+            )
             castle_statement_found = True
             break
     assert castle_statement_found, (
@@ -173,7 +187,10 @@ async def test_add_entities_with_character_labeling(mock_neo4j_manager):
     charles_statement_found = False
     for query, params in captured_statements_for_tests:
         if params.get("object_name_param") == "Charles":
-            assert "MERGE (o:Character:Entity {name: $object_name_param})" in query
+            assert (
+                "MERGE (o:Character:Entity {name: $object_name_param})"
+                in query
+            )
             charles_statement_found = True
             break
     assert charles_statement_found, (
@@ -185,7 +202,8 @@ async def test_add_entities_with_character_labeling(mock_neo4j_manager):
     for query, params in captured_statements_for_tests:
         if params.get("object_name_param") == "Diana":
             assert (
-                "MERGE (o:Character:Person:Entity {name: $object_name_param})" in query
+                "MERGE (o:Character:Person:Entity {name: $object_name_param})"
+                in query
             )
             diana_statement_found = True
             break
@@ -303,7 +321,7 @@ async def test_query_retrieves_all_character_types(mock_neo4j_manager):
     # Let's simplify this test to focus on the fact that query_kg_from_db *can* retrieve
     # data if the entities were labeled correctly.
 
-    results = await query_kg_from_db(include_provisional=True)  # general query
+    await query_kg_from_db(include_provisional=True)  # general query
     assert (
         "MATCH (s:Entity)-[r:DYNAMIC_REL]->(o)" in captured_query_string
     )  # default query

--- a/tests/test_cypher_generation.py
+++ b/tests/test_cypher_generation.py
@@ -15,7 +15,10 @@ def test_generate_character_node_cypher():
 
 def test_generate_world_element_node_cypher():
     item = WorldItem(
-        "places_city", "Places", "City", properties={"description": "Metropolis"}
+        "places_city",
+        "Places",
+        "City",
+        properties={"description": "Metropolis"},
     )
     stmts = generate_world_element_node_cypher(item)
     assert any("MERGE (we:Entity" in s[0] for s in stmts)

--- a/tests/test_initial_setup_logic.py
+++ b/tests/test_initial_setup_logic.py
@@ -7,7 +7,6 @@ import json
 from initial_setup_logic import (
     generate_world_building_logic,
     WORLD_CATEGORY_MAP_NORMALIZED_TO_INTERNAL,
-    WORLD_DETAIL_KEY_MAP_FROM_MARKDOWN_TO_INTERNAL,
     WORLD_DETAIL_LIST_INTERNAL_KEYS,
 )
 import config  # For config.MARKDOWN_FILL_IN_PLACEHOLDER and other config values if needed
@@ -49,7 +48,10 @@ async def test_valid_json_output_from_llm(agent_instance):
         "factions": {
             "Desert Nomads": {
                 "description": "Tribes that roam the great sands.",
-                "goals": ["Survive the harsh conditions", "Find new water sources"],
+                "goals": [
+                    "Survive the harsh conditions",
+                    "Find new water sources",
+                ],
                 "structure": "Tribal councils",
             }
         },
@@ -67,7 +69,10 @@ async def test_valid_json_output_from_llm(agent_instance):
         await generate_world_building_logic(agent_instance)
 
     wb = agent_instance.world_building
-    assert wb["_overview_"]["description"] == "A vast desert planet with twin suns."
+    assert (
+        wb["_overview_"]["description"]
+        == "A vast desert planet with twin suns."
+    )
     assert wb["_overview_"]["mood"] == "Harsh and unforgiving"
 
     assert "Oasis City" in wb["locations"]
@@ -99,9 +104,7 @@ async def test_valid_json_output_from_llm(agent_instance):
 @pytest.mark.asyncio
 async def test_invalid_json_output_decode_error(agent_instance):
     """Test handling of JSONDecodeError when LLM output is malformed."""
-    malformed_json_str = (
-        '{"overview": {"description": "A broken world..."'  # Missing closing brace
-    )
+    malformed_json_str = '{"overview": {"description": "A broken world..."'  # Missing closing brace
     mock_llm_output = (
         malformed_json_str,
         {"prompt_tokens": 5, "completion_tokens": 10, "total_tokens": 15},
@@ -227,7 +230,10 @@ async def test_llm_output_missing_category(agent_instance):
     # Check that all categories defined in WORLD_CATEGORY_MAP_NORMALIZED_TO_INTERNAL exist
     # For missing ones like 'factions', they should be initialized as empty dicts by the end of the function
     # if the source is not user_supplied_yaml (which it isn't in this LLM-only flow)
-    for cat_norm, cat_internal in WORLD_CATEGORY_MAP_NORMALIZED_TO_INTERNAL.items():
+    for (
+        cat_norm,
+        cat_internal,
+    ) in WORLD_CATEGORY_MAP_NORMALIZED_TO_INTERNAL.items():
         assert cat_internal in wb
         if cat_norm not in json_payload_missing_category:
             assert wb[cat_internal] == {}  # Should be initialized as empty
@@ -303,7 +309,9 @@ async def test_existing_user_data_preserved_and_llm_fills_gaps(agent_instance):
             "User Keep": {
                 "description": "LLM tries to change this.",  # Should be ignored
                 "atmosphere": "LLM tries to change this too.",  # Should be ignored
-                "features": ["New LLM feature"],  # This is a new field, should be added
+                "features": [
+                    "New LLM feature"
+                ],  # This is a new field, should be added
             },
             "LLM Lava Caves": {
                 "description": "Dangerous lava caves from LLM.",
@@ -313,7 +321,10 @@ async def test_existing_user_data_preserved_and_llm_fills_gaps(agent_instance):
         "factions": {  # LLM generates this category
             "Sun Scorched Clan": {
                 "description": "A clan adapted to extreme heat.",
-                "goals": ["Find the legendary Sunstone", "Appease the Sun God"],
+                "goals": [
+                    "Find the legendary Sunstone",
+                    "Appease the Sun God",
+                ],
             }
         },
     }
@@ -332,13 +343,16 @@ async def test_existing_user_data_preserved_and_llm_fills_gaps(agent_instance):
     wb = agent_instance.world_building
 
     # Overview: User's description preserved, LLM's mood used for [Fill-in]
-    assert wb["_overview_"]["description"] == "User's original world description."
+    assert (
+        wb["_overview_"]["description"] == "User's original world description."
+    )
     assert wb["_overview_"]["mood"] == "Mystical and vibrant (from LLM)"
 
     # Locations: User Keep's original details preserved, new field 'features' added by LLM
     assert "User Keep" in wb["locations"]
     assert (
-        wb["locations"]["User Keep"]["description"] == "A sturdy keep from user data."
+        wb["locations"]["User Keep"]["description"]
+        == "A sturdy keep from user data."
     )
     assert wb["locations"]["User Keep"]["atmosphere"] == "Ancient and strong"
     assert wb["locations"]["User Keep"]["features"] == ["New LLM feature"]
@@ -432,7 +446,9 @@ async def test_generate_world_building_mixed_llm_output_format(agent_instance):
     # "overall_vibe", "non_list_property_for_default", "unnormalized_default_prop"
 
     # Create a combined list for patching, ensuring no duplicates and preserving originals
-    mock_list_keys_content = list(set(original_list_keys + test_specific_list_keys))
+    mock_list_keys_content = list(
+        set(original_list_keys + test_specific_list_keys)
+    )
 
     # Patch the global list within the 'initial_setup_logic' module for the duration of this test
     with (
@@ -479,7 +495,10 @@ async def test_generate_world_building_mixed_llm_output_format(agent_instance):
     # Assuming "Key Elements" maps to "key_elements" or is used as is.
     # The key "Key Elements" is not in WORLD_DETAIL_KEY_MAP_FROM_MARKDOWN_TO_INTERNAL, internal_item_key_for_agent = "Key Elements"
     # "Key Elements" IS in mock_list_keys_content (due to test_specific_list_keys). So, not wrapped.
-    assert default_item.get("Key Elements") == ["Ancient Scrolls", "Whispering Winds"]
+    assert default_item.get("Key Elements") == [
+        "Ancient Scrolls",
+        "Whispering Winds",
+    ]
 
     # 'NonListPropertyForDefault' is NOT in mock_list_keys_content, so its list value should be wrapped.
     # internal_item_key_for_agent = "NonListPropertyForDefault"
@@ -503,7 +522,9 @@ async def test_generate_world_building_mixed_llm_output_format(agent_instance):
         "text": "A library lost to the depths, holding ancient secrets."
     }
     # 'atmosphere' is not in WORLD_DETAIL_LIST_INTERNAL_KEYS
-    assert sunken_library.get("atmosphere") == {"text": "Mysterious and silent"}
+    assert sunken_library.get("atmosphere") == {
+        "text": "Mysterious and silent"
+    }
 
     # --- Proper Item Asserts ("Dragon's Peak") ---
     assert "Dragon's Peak" in lore_category_data

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -17,14 +17,20 @@ def test_merge_world_item_updates():
     current = {
         "Places": {
             "City": WorldItem(
-                "Places_City", "Places", "City", properties={"description": "Old"}
+                "Places_City",
+                "Places",
+                "City",
+                properties={"description": "Old"},
             )
         }
     }
     updates = {
         "Places": {
             "City": WorldItem(
-                "Places_City", "Places", "City", properties={"description": "New"}
+                "Places_City",
+                "Places",
+                "City",
+                properties={"description": "New"},
             )
         }
     }

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,9 +1,11 @@
-import json  # For creating JSON strings if needed, though direct strings are fine
 from kg_maintainer.parsing import (  # Assuming parsing is now a module inside kg_maintainer
     parse_unified_character_updates,
     parse_unified_world_updates,
 )
-from kg_maintainer.models import CharacterProfile, WorldItem  # Added WorldItem import
+from kg_maintainer.models import (
+    CharacterProfile,
+    WorldItem,
+)  # Added WorldItem import
 
 # Example of a helper to create JSON strings for tests if they get complex
 # def make_json_string(data_dict):
@@ -55,7 +57,9 @@ def test_parse_character_updates_simple_json():
 def test_parse_character_updates_empty_or_invalid_json():
     assert parse_unified_character_updates("", 1) == {}
     assert parse_unified_character_updates("{}", 1) == {}
-    assert parse_unified_character_updates("[]", 1) == {}  # Not a dict of characters
+    assert (
+        parse_unified_character_updates("[]", 1) == {}
+    )  # Not a dict of characters
     assert parse_unified_character_updates("invalid json", 1) == {}
     # Test with a valid JSON but not the expected structure (e.g. list at root)
     assert parse_unified_character_updates('[{"name": "Alice"}]', 1) == {}
@@ -124,7 +128,9 @@ def test_parse_world_updates_simple_json():
 
     assert "Overview" in result
     overview_cat = result["Overview"]
-    assert "_overview_" in overview_cat  # Overview item is stored with key "_overview_"
+    assert (
+        "_overview_" in overview_cat
+    )  # Overview item is stored with key "_overview_"
     overview_item = overview_cat["_overview_"]
     assert isinstance(overview_item, WorldItem)
     assert overview_item.category == "Overview"  # Category name from JSON
@@ -140,10 +146,15 @@ def test_parse_world_updates_simple_json():
 def test_parse_world_updates_empty_or_invalid_json():
     assert parse_unified_world_updates("", 1) == {}
     assert parse_unified_world_updates("{}", 1) == {}
-    assert parse_unified_world_updates("[]", 1) == {}  # Not a dict of categories
+    assert (
+        parse_unified_world_updates("[]", 1) == {}
+    )  # Not a dict of categories
     assert parse_unified_world_updates("invalid json", 1) == {}
     # Test with valid JSON but not expected structure (e.g. category content is not a dict of items)
-    assert parse_unified_world_updates('{"Locations": ["City1", "City2"]}', 1) == {}
+    assert (
+        parse_unified_world_updates('{"Locations": ["City1", "City2"]}', 1)
+        == {}
+    )
 
 
 # It might be good to add more tests:

--- a/tests/test_parsing_utils.py
+++ b/tests/test_parsing_utils.py
@@ -43,7 +43,8 @@ class TestRdfTripleParsing(unittest.TestCase):
             (
                 t
                 for t in parsed_triples
-                if t["subject"]["name"] == "Jax" and t["predicate"] == "hasAlias"
+                if t["subject"]["name"] == "Jax"
+                and t["predicate"] == "hasAlias"
             ),
             None,
         )
@@ -61,17 +62,21 @@ class TestRdfTripleParsing(unittest.TestCase):
             (
                 t
                 for t in parsed_triples
-                if t["subject"]["name"] == "Jax" and t["predicate"] == "livesIn"
+                if t["subject"]["name"] == "Jax"
+                and t["predicate"] == "livesIn"
             ),
             None,
         )
-        self.assertIsNotNone(jax_livesin_triple, "Jax livesIn triple not found")
+        self.assertIsNotNone(
+            jax_livesin_triple, "Jax livesIn triple not found"
+        )
         if jax_livesin_triple:
             self.assertFalse(jax_livesin_triple["is_literal_object"])
             self.assertIsNotNone(jax_livesin_triple["object_entity"])
             if jax_livesin_triple["object_entity"]:
                 self.assertEqual(
-                    jax_livesin_triple["object_entity"]["name"], "Hourglass Curios"
+                    jax_livesin_triple["object_entity"]["name"],
+                    "Hourglass Curios",
                 )
                 self.assertEqual(
                     jax_livesin_triple["object_entity"]["type"], "Location"
@@ -87,7 +92,9 @@ class TestRdfTripleParsing(unittest.TestCase):
             ),
             None,
         )
-        self.assertIsNotNone(jax_type_triple, "Jax rdf:type Character triple not found")
+        self.assertIsNotNone(
+            jax_type_triple, "Jax rdf:type Character triple not found"
+        )
 
         lila_type_triple = next(
             (
@@ -108,9 +115,7 @@ class TestRdfTripleParsing(unittest.TestCase):
         self.assertEqual(len(parsed_triples), 0)
 
     def test_invalid_turtle(self):
-        invalid_turtle = (
-            r"@prefix : <http://example.org/saga/> . char:Jax prop:hasAlias 'J.X.'"
-        )
+        invalid_turtle = r"@prefix : <http://example.org/saga/> . char:Jax prop:hasAlias 'J.X.'"
         parsed_triples = parse_rdf_triples_with_rdflib(
             invalid_turtle, rdf_format="turtle"
         )

--- a/tests/test_yaml_parser.py
+++ b/tests/test_yaml_parser.py
@@ -20,7 +20,9 @@ class TestYamlParsing(unittest.TestCase):
         with open(self.valid_yaml_filepath, "w", encoding="utf-8") as f:
             yaml.dump(self.valid_yaml_content, f)
 
-        self.malformed_yaml_filepath = os.path.join(self.test_dir, "malformed.yaml")
+        self.malformed_yaml_filepath = os.path.join(
+            self.test_dir, "malformed.yaml"
+        )
         with open(self.malformed_yaml_filepath, "w", encoding="utf-8") as f:
             f.write(
                 "Novel Concept: Title: Test Novel\nGenre: [Sci-Fi"
@@ -33,7 +35,9 @@ class TestYamlParsing(unittest.TestCase):
         self.non_dict_root_yaml_filepath = os.path.join(
             self.test_dir, "non_dict_root.yaml"
         )
-        with open(self.non_dict_root_yaml_filepath, "w", encoding="utf-8") as f:
+        with open(
+            self.non_dict_root_yaml_filepath, "w", encoding="utf-8"
+        ) as f:
             f.write("- item1\n- item2")  # Root is a list
 
     def tearDown(self):
@@ -73,7 +77,9 @@ class TestYamlParsing(unittest.TestCase):
 
     def test_load_empty_yaml(self):
         data = load_yaml_file(self.empty_yaml_filepath)
-        self.assertEqual(data, {})  # Expecting an empty dictionary for an empty file
+        self.assertEqual(
+            data, {}
+        )  # Expecting an empty dictionary for an empty file
 
     def test_load_non_dict_root_yaml(self):
         # Current implementation of load_yaml_file logs error and returns None if root is not dict


### PR DESCRIPTION
## Summary
- remove unused imports in tests
- wrap long lines in tests

## Testing
- `ruff check tests`
- `ruff format --check .` *(fails: Would reformat: comprehensive_evaluator_agent.py, config.py, ...)*
- `mypy .` *(fails: Library stubs not installed for "yaml", etc.)*
- `pytest tests -v` *(fails: 7 failed, 26 passed, 10 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_684233cbf510832f9d2429f4684e9e34