### PR TITLE
Fix: Use MERGE with :Character label to prevent constraint violation

### DIFF
--- a/kg_maintainer/cypher_generation.py
+++ b/kg_maintainer/cypher_generation.py
@@ -62,7 +62,7 @@ def generate_character_node_cypher(
     statements.append(
         (
             """
-            MERGE (c:Entity {name: $name})
+            MERGE (c:Character:Entity {name: $name})
             ON CREATE SET
                 c:Character,
                 c += $props,


### PR DESCRIPTION
The previous Cypher generation for character nodes used: MERGE (c:Entity {name: $name})
ON MATCH SET c:Character
ON CREATE SET c:Character

This could lead to a Neo.ClientError.Schema.ConstraintValidationFailed if an :Entity with the same name already existed but was not yet a :Character, and a separate :Character node with that name also existed. The attempt to add the :Character label to the first entity would then conflict with the unique constraint on (:Character {name}).

This commit changes the MERGE statement to:
MERGE (c:Character:Entity {name: $name})

This ensures that the operation correctly targets an existing :Character:Entity node by name or creates a new one with both labels and the name from the outset, aligning with the uniqueness constraint `character_name_unique` which requires `char.name` to be unique for nodes with the `Character` label.

Dependent MATCH statements for characters already correctly use `MATCH (c:Character:Entity {name: $name})` and are unaffected.

Note: A similar MERGE pattern exists for target characters in relationships: `MERGE (c2:Entity {name: $target_name}) ON CREATE SET c2:Character ON MATCH SET c2:Character`. This could potentially cause the same issue if a target character name has a similar conflicting state in the database. This was not addressed in this commit as the reported error was for a primary character profile.