### PR TITLE
Fix: Improve YAML parsing, KG triple robustness, and character initialization

### DIFF
--- a/parsing_utils.py
+++ b/parsing_utils.py
@@ -72,13 +72,20 @@ def parse_rdf_triples_with_rdflib(
             continue
 
         parts = [p.strip() for p in line.split("|")]
-        if len(parts) != 3:
+        if len(parts) < 3:
             logger_func.warning(
-                f"Line {line_num + 1}: Malformed triple (expected 3 parts separated by '|'): '{line}'"
+                f"Line {line_num + 1}: Malformed triple (expected at least 3 parts separated by '|'): '{line}'"
             )
             continue
 
-        subject_text, predicate_text, object_text = parts
+        subject_text = parts[0]
+        predicate_text = parts[1]
+        object_text = parts[2]
+
+        if len(parts) > 3:
+            logger_func.debug(
+                f"Line {line_num + 1}: Triple had extra parts which are being ignored: '{' | '.join(parts[3:])}' from original line '{line}'"
+            )
 
         subject_details = _get_entity_type_and_name_from_text(subject_text)
         predicate_str = (


### PR DESCRIPTION
This commit incorporates three fixes:

1.  **YAML Plot Elements Parsing:**
    I modified `_populate_agent_state_from_user_data` in
    `initial_setup_logic.py` to correctly parse the `plot_elements`
    section (containing `inciting_incident`, `key_plot_points`,
    `central_conflict`, `stakes`) from `user_story_elements.yaml`.
    This ensures your provided plot details are loaded into my
    state. `PLOT_OUTLINE_KEY_MAP` was updated for `stakes`.

2.  **Malformed KG Triple Handling:**
    I updated `parse_rdf_triples_with_rdflib` in `parsing_utils.py`
    to robustly handle LLM-generated KG triples that may contain
    extra parts (e.g., comments after the S-P-O). The parser now
    uses the first three parts if at least three are present and logs
    any additional parts at a debug level, preventing parsing errors.

3.  **CharacterProfile Initialization:**
    I refactored `_populate_agent_state_from_user_data` in
    `initial_setup_logic.py` to ensure that character data (protagonist,
    antagonist, other key characters) loaded from YAML is immediately
    instantiated and stored as `CharacterProfile` objects in
    `agent.character_profiles`. This prevents downstream warnings about
    corrupted state (e.g. character being a dict instead of an instance).

These changes improve the reliability of initial world-building from YAML,
make knowledge graph extraction more resilient, and ensure consistent
data typing for character profiles.