### PR TITLE
Centralize novel info query helpers

### DIFF
--- a/data_access/__init__.py
+++ b/data_access/__init__.py
@@ -2,29 +2,34 @@
 # This file makes the data_access directory a Python package.
 # You can also use it to expose a simpler API from this package if desired.
 
-from .plot_queries import save_plot_outline_to_db, get_plot_outline_from_db
-from .character_queries import (
-    sync_full_state_from_object_to_db as sync_characters_full_state_from_object_to_db,
-    get_character_profiles_from_db,
-    get_character_info_for_snippet_from_db,
-)
-from .world_queries import (
-    sync_full_state_from_object_to_db as sync_world_full_state_from_object_to_db,
-    get_world_building_from_db,
-    get_world_elements_for_snippet_from_db,
-)
 from .chapter_queries import (
-    load_chapter_count_from_db,
-    save_chapter_data_to_db,
-    get_chapter_data_from_db,
-    get_embedding_from_db,
     find_similar_chapters_in_db,
     get_all_past_embeddings_from_db,
+    get_chapter_data_from_db,
+    get_embedding_from_db,
+    load_chapter_count_from_db,
+    save_chapter_data_to_db,
+)
+from .character_queries import (
+    get_character_info_for_snippet_from_db,
+    get_character_profiles_from_db,
+)
+from .character_queries import (
+    sync_full_state_from_object_to_db as sync_characters_full_state_from_object_to_db,
 )
 from .kg_queries import (
     add_kg_triples_batch_to_db,
-    query_kg_from_db,
     get_most_recent_value_from_db,
+    get_novel_info_property_from_db,
+    query_kg_from_db,
+)
+from .plot_queries import get_plot_outline_from_db, save_plot_outline_to_db
+from .world_queries import (
+    get_world_building_from_db,
+    get_world_elements_for_snippet_from_db,
+)
+from .world_queries import (
+    sync_full_state_from_object_to_db as sync_world_full_state_from_object_to_db,
 )
 
 __all__ = [
@@ -45,4 +50,5 @@ __all__ = [
     "add_kg_triples_batch_to_db",
     "query_kg_from_db",
     "get_most_recent_value_from_db",
+    "get_novel_info_property_from_db",
 ]


### PR DESCRIPTION
## Summary
- move novel info query logic into `kg_queries`
- expose `get_novel_info_property_from_db`
- use helper inside `prompt_data_getters`

## Testing
- `ruff check .`
- `ruff format --check .` *(fails: Would reformat tests/test_agent_extract.py...)*
- `pytest tests/ -v --cov=. --cov-report=term-missing` *(fails: unrecognized arguments)*
- `mypy .` *(fails: found 34 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68438b429cb4832f812d461d878a527e