### PR TITLE
feat(agents): render chapter drafts via templates

### DIFF
--- a/prompt_renderer.py
+++ b/prompt_renderer.py
@@ -1,12 +1,12 @@
+"""Utilities for rendering LLM prompts using Jinja2 templates."""
+
 from pathlib import Path
 from typing import Any, Dict
 
-from jinja2 import Environment, FileSystemLoader, select_autoescape
+from jinja2 import Environment, FileSystemLoader
 
 PROMPTS_PATH = Path(__file__).parent / "prompts"
-_env = Environment(
-    loader=FileSystemLoader(PROMPTS_PATH), autoescape=select_autoescape()
-)
+_env = Environment(loader=FileSystemLoader(PROMPTS_PATH), autoescape=False)
 
 
 def render_prompt(template_name: str, context: Dict[str, Any]) -> str:

--- a/prompt_renderer.py
+++ b/prompt_renderer.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+from typing import Any, Dict
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+PROMPTS_PATH = Path(__file__).parent / "prompts"
+_env = Environment(
+    loader=FileSystemLoader(PROMPTS_PATH), autoescape=select_autoescape()
+)
+
+
+def render_prompt(template_name: str, context: Dict[str, Any]) -> str:
+    """Render a Jinja2 template from the prompts directory."""
+    template = _env.get_template(template_name)
+    return template.render(**context)

--- a/prompts/comprehensive_evaluator_agent/evaluate_chapter.j2
+++ b/prompts/comprehensive_evaluator_agent/evaluate_chapter.j2
@@ -1,0 +1,51 @@
+{% if no_think %}/no_think
+{% endif %}You are a Master Editor evaluating Chapter {{ chapter_number }} of a novel titled "{{ novel_title }}" (Protagonist: {{ protagonist_name_str }}).
+Analyze the **Complete Chapter Text** provided below.
+Your task is to identify specific issues related to these EXACT categories:
+1.  **CONSISTENCY**
+2.  **PLOT_ARC**
+3.  **THEMATIC_ALIGNMENT**
+4.  **NARRATIVE_DEPTH_AND_LENGTH** (target: at least {{ min_length }} characters)
+
+**Reference Information for CONSISTENCY Check (Summary Format):**
+  **Plot Outline Summary:**
+  ```text
+  Title: {{ novel_title }}
+  Genre: {{ novel_genre }}
+  Theme: {{ novel_theme }}
+  Protagonist: {{ novel_protagonist }} ({{ protagonist_arc }})
+  Logline: {{ logline }}
+  Key Plot Points (summary):
+  {{ plot_points_summary_str }}
+  ```
+  **Character Profiles (Key Info - check 'prompt_notes' for provisional status):**
+  ```text
+  {{ char_profiles_plain_text }}
+  ```
+  **World Building Notes (Key Info - check 'prompt_notes' for provisional status):**
+  ```text
+  {{ world_building_plain_text }}
+  ```
+  {{ kg_check_results_text }}
+  **Previous Chapters Context (Semantic Flow & KG Facts for Canon):**
+  --- PREVIOUS CONTEXT ---
+  {{ previous_chapters_context if previous_chapters_context.strip() else 'N/A (e.g., Chapter 1 or context retrieval failed).' }}
+  --- END PREVIOUS CONTEXT ---
+
+**Complete Chapter {{ chapter_number }} Text (to analyze):**
+--- BEGIN COMPLETE CHAPTER TEXT ---
+{{ draft_text }}
+--- END COMPLETE CHAPTER TEXT ---
+
+**Output Format (CRITICAL - JSON ONLY):**
+Provide your evaluation as a JSON array of problem objects. Each object must have these keys: "issue_category", "problem_description", "quote_from_original_text", "suggested_fix_focus".
+For `issue_category`, use one of the EXACT category names: CONSISTENCY, PLOT_ARC, THEMATIC_ALIGNMENT, NARRATIVE_DEPTH_AND_LENGTH.
+The `quote_from_original_text` must be a VERBATIM quote (10-50 words) from the chapter text. If general or no quote applies, use "N/A - General Issue".
+If NO problems are found, output an empty JSON array `[]` or a JSON object like {"status": "No significant problems found"}.
+
+**Follow this example structure for your JSON output precisely:**
+```json
+{{ few_shot_eval_example_str.strip() }}
+```
+
+Begin your JSON output now:

--- a/prompts/drafting_agent/draft_chapter.j2
+++ b/prompts/drafting_agent/draft_chapter.j2
@@ -1,0 +1,25 @@
+{% if no_think %}/no_think
+{% endif %}You are an expert creative writer, drafting Chapter {{ chapter_number }} of the novel "{{ novel_title }}".
+Novel Genre: {{ novel_genre }}. Novel Theme: {{ novel_theme }}. Protagonist: {{ protagonist_name }}.
+Your goal is to write compelling, engaging prose that brings the story to life.
+
+**Primary Plot Point Focus for THIS Chapter (Chapter {{ chapter_number }}):**
+{{ plot_point_focus }}
+
+{{ scene_plan_prompt_text }}
+
+**Hybrid Context (Past Chapters & KG Facts - for narrative flow, tone, and established canon):**
+{{ hybrid_context_for_draft }}
+
+**Writing Instructions:**
+- Write Chapter {{ chapter_number }} in a complete and coherent manner.
+- Adhere closely to the 'Detailed Scene Plan' if provided. Each scene should flow logically to the next.
+- If no detailed scene plan is available, use the 'Primary Plot Point Focus' to structure the chapter with a clear beginning, middle, and end, incorporating multiple distinct scenes or events as appropriate to achieve the plot point.
+- Ensure the narrative style is consistent with the genre and tone implied by the context.
+- Develop characters through their actions, dialogue, and internal thoughts.
+- Weave in setting details naturally to create a vivid world.
+- Aim for a substantial chapter length, typically at least {{ min_length }} characters.
+- Conclude the chapter appropriately, leading towards the next phase of the story if applicable, but resolve the immediate focus of *this* chapter's plot point.
+- Do NOT include any preambles, summaries, author notes, or section headers like "Chapter X" in your output. Output ONLY the chapter text itself.
+
+Begin writing Chapter {{ chapter_number }} now:

--- a/prompts/kg_maintainer_agent/chapter_summary.j2
+++ b/prompts/kg_maintainer_agent/chapter_summary.j2
@@ -1,0 +1,11 @@
+{% if no_think %}/no_think
+{% endif %}You are a concise summarizer. Summarize the key events, character developments, and plot advancements from the following Chapter {{ chapter_number }} text.
+The summary should be 1-3 sentences long and capture the most crucial information.
+Focus on what changed or was revealed.
+
+Full Chapter Text:
+--- BEGIN TEXT ---
+{{ chapter_text }}
+--- END TEXT ---
+
+Output ONLY the summary text. No extra commentary or "Summary:" prefix.

--- a/prompts/kg_maintainer_agent/extract_updates.j2
+++ b/prompts/kg_maintainer_agent/extract_updates.j2
@@ -1,0 +1,69 @@
+{% if no_think %}/no_think
+{% endif %}You are an AI assistant specialized in analyzing fictional narrative text. Your task is to extract structured information about characters and world elements, and identify key relationships or events as KG triples.
+The story's protagonist is: {{ protagonist }}.
+This is Chapter {{ chapter_number }} of the novel titled '{{ novel_title }}' (Genre: {{ novel_genre }}).
+Focus on information explicitly stated or strongly implied in the provided chapter text.
+Output the extracted information in three distinct sections, using these exact headers:
+### CHARACTER UPDATES ###
+### WORLD UPDATES ###
+### KG TRIPLES ###
+
+For CHARACTER UPDATES: Output a JSON object where keys are character names. Each character's value should be another JSON object containing their attributes (e.g., {"status": "injured", "description": "now wears a red cloak"}).
+- For traits, use a key like "traits" with a JSON array of strings: ["trait1", "trait2"]. List only new or emphasized traits.
+- For relationships, use a key like "relationships" with a JSON object where keys are target character names and values are strings describing the relationship change/nuance: {"Target Character": "became allies"}.
+- Include a key "development_in_chapter_{{ chapter_number }}" with a brief note of the character's development.
+Example for Character Updates (JSON format):
+```json
+{
+  "Elara Voss": {
+    "status": "determined",
+    "traits": ["curious", "introspective"],
+    "relationships": {"Her Father": "vanished, left clues"},
+    "development_in_chapter_{{ chapter_number }}": "Discovered father's journal."
+  }
+}
+```
+
+For WORLD UPDATES: Output a JSON object where keys are category names (e.g., "Locations", "Factions"). Each category's value should be another JSON object where keys are item names and values are their attribute objects.
+- Each item's attribute object should contain keys like "description", "atmosphere", etc., with string values.
+- For list-like details (e.g. "rules" for a system), use a JSON array of strings.
+- Include a key "elaboration_in_chapter_{{ chapter_number }}" with a note on how this item was detailed or interacted with.
+Example for World Updates (JSON format):
+```json
+{
+  "Locations": {
+    "Ancient Cabin": {
+      "description": "Wooden frame, half-buried in snow.",
+      "atmosphere": "Frozen in time, eerie silence.",
+      "elaboration_in_chapter_{{ chapter_number }}": "Visited by Elara, map found here."
+    }
+  },
+  "WorldElements": {
+    "Echoes": {
+      "description": "Forces of balance, threads of memory.",
+      "elaboration_in_chapter_{{ chapter_number }}": "Elara learns they are ancient forces."
+    }
+  }
+}
+```
+
+For KG TRIPLES:
+- List factual statements on separate lines (plain text, NOT JSON for this section).
+- Format: 'SubjectEntityType:SubjectName | Predicate | ObjectEntityType:ObjectName' OR 'SubjectEntityType:SubjectName | Predicate | LiteralValue'.
+- Valid Subject/Object EntityTypes: Character, WorldElement, Location, Faction, Item, Concept, Trait, Event, PlotPoint, Organization, Species, Ability, MagicSystem, Technology, Currency, Language, Food, Plant, Animal, Vehicle, Weapon, Armor, Clothing, Tool, Building, Region, Planet, StarSystem, Galaxy, Dimension, HistoricalPeriod, CulturalAspect, SocialClass, Occupation, Title, Role, StatusEffect, Quest, LoreFragment, Prophecy, Rumor, Secret.
+  If type is ambiguous or general for a specific subject/object, you can omit its type prefix (e.g., 'Lirion | DEFEATED | Goblin Chieftain').
+  For WorldElements, use their human-readable name, not their category_name ID.
+- Examples:
+  'Character:Lirion | DISCOVERED | Location:HiddenCave'
+  'WorldElement:Sunstone | HAS_PROPERTY | EmitsWarmth'
+  'Character:Elara | LEARNED_SKILL | Trait:Herbalism'
+  'Event:FestivalOfLights | OCCURRED_IN | Location:SilvermoonCity'
+  'Lirion | HAS_STATUS | Injured'
+  'Character:Borin | HAS_AGE | 45'
+- Predicates should be concise verbs or descriptive phrases in uppercase (e.g., 'HAS_ABILITY', 'LOCATED_IN', 'DISCOVERED_ARTIFACT', 'IS_FRIENDLY_WITH', 'FEELS_EMOTION_TOWARDS').
+- Subjects and Objects should be specific entity names or literal values.
+- Prioritize triples that represent significant plot events, new knowledge, or changes in state.
+--- BEGIN CHAPTER TEXT ---
+{{ chapter_text }}
+--- END CHAPTER TEXT ---
+Ensure your output adheres strictly to this format. Provide only the requested sections and their content.

--- a/prompts/planner_agent/scene_plan.j2
+++ b/prompts/planner_agent/scene_plan.j2
@@ -1,0 +1,40 @@
+{% if no_think %}/no_think
+{% endif %}You are a master plotter outlining **between {{ target_scenes_min }} and {{ target_scenes_max }} detailed scenes** for Chapter {{ chapter_number }} of a novel.
+This chapter is part of a larger narrative arc.
+
+**Novel Concept:**
+  - Title: {{ novel_title }}
+  - Genre: {{ novel_genre }}
+  - Theme: {{ novel_theme }}
+  - Protagonist: {{ protagonist_name }}
+  - Protagonist's Arc: {{ protagonist_arc }}
+
+**Overall Narrative Context:** This chapter focuses on Plot Point {{ plot_point_index_plus1 }} of {{ total_plot_points_in_novel }} total major plot points in the novel.
+
+**Mandatory Focus for THIS Chapter (Plot Point {{ plot_point_index_plus1 }}):**
+{{ plot_point_focus }}
+
+{{ future_plot_context_str }}**Recent Context from Previous Chapter(s) (Semantic context & KG Facts):**
+{{ context_summary_str if context_summary_str else "This is the first chapter, or no prior summary is available." }}
+{{ kg_context_section }}
+**Current Character States (Key Characters, based on profiles and recent developments - Plain Text):**
+{{ character_state_snippet_plain_text }}
+
+**Current World State (Relevant Locations/Elements, based on world-building - Plain Text):**
+{{ world_state_snippet_plain_text }}
+
+**Task:**
+Create a detailed plan of {{ target_scenes_min }} to {{ target_scenes_max }} scenes for Chapter {{ chapter_number }}.
+These scenes should *primarily advance the Mandatory Focus Plot Point* for this chapter. Do NOT attempt to resolve future plot points in these scenes.
+**Task:**
+Create a detailed plan of {{ target_scenes_min }} to {{ target_scenes_max }} scenes for Chapter {{ chapter_number }}, formatted as a JSON array of scene objects.
+These scenes should *primarily advance the Mandatory Focus Plot Point* for this chapter. Do NOT attempt to resolve future plot points in these scenes.
+Each scene object in the JSON array must have the following keys:
+"scene_number" (integer), "summary" (string), "characters_involved" (array of strings), "key_dialogue_points" (array of strings), "setting_details" (string), "scene_focus_elements" (array of strings), "contribution" (string).
+
+**Follow this example structure for your JSON output precisely:**
+```json
+{{ few_shot_scene_plan_example_str.strip() }}
+```
+
+Output ONLY the JSON array of scene objects.

--- a/prompts/world_continuity_agent/consistency_check.j2
+++ b/prompts/world_continuity_agent/consistency_check.j2
@@ -1,0 +1,50 @@
+{% if no_think %}/no_think
+{% endif %}You are a World & Continuity Expert Editor for Chapter {{ chapter_number }} of the novel "{{ novel_title }}" (Protagonist: {{ protagonist_name_str }}).
+Your SOLE TASK is to identify specific CONSISTENCY issues in the **Complete Chapter Text** below. Focus on:
+- Contradictions with the Plot Outline summary.
+- Contradictions with Character Profiles (descriptions, established traits, known status, relationships).
+- Contradictions with World Building rules, descriptions, or established lore.
+- Contradictions or inconsistencies with the Previous Chapters Context (which includes semantic flow and Key Reliable KG Facts).
+- Internal inconsistencies of fact or established detail within THIS chapter's text.
+
+**Reference Information for CONSISTENCY Check (Summary Format):**
+  **Plot Outline Summary:**
+  ```text
+  Title: {{ novel_title }}
+  Genre: {{ novel_genre }}
+  Theme: {{ novel_theme }}
+  Protagonist: {{ novel_protagonist }} ({{ protagonist_arc }})
+  Logline: {{ logline }}
+  Key Plot Points (summary):
+  {{ plot_points_summary_str }}
+  ```
+  **Character Profiles (Key Info - check 'prompt_notes' for provisional status):**
+  ```text
+  {{ char_profiles_plain_text }}
+  ```
+  **World Building Notes (Key Info - check 'prompt_notes' for provisional status):**
+  ```text
+  {{ world_building_plain_text }}
+  ```
+  **Previous Chapters Context (Includes Semantic Flow & Key Reliable KG Facts for Canon):**
+  --- PREVIOUS CONTEXT ---
+  {{ previous_chapters_context if previous_chapters_context.strip() else 'N/A (e.g., Chapter 1 or context retrieval failed).' }}
+  --- END PREVIOUS CONTEXT ---
+
+**Complete Chapter {{ chapter_number }} Text (to analyze for consistency):**
+--- BEGIN COMPLETE CHAPTER TEXT ---
+{{ draft_text }}
+--- END COMPLETE CHAPTER TEXT ---
+
+**Output Format (CRITICAL - JSON ONLY):**
+If consistency problems are found, output a JSON array of problem objects.
+Each object MUST have these keys: "issue_category" (fixed to "consistency"), "problem_description", "quote_from_original_text", "suggested_fix_focus".
+The `quote_from_original_text` must be a VERBATIM quote (10-50 words) from the chapter text. If general or no quote applies, use "N/A - General Issue".
+If NO consistency problems are found, output an empty JSON array `[]` or a JSON object like {"status": "No significant consistency problems found"}.
+
+**Follow this example structure for your JSON output precisely:**
+```json
+{{ few_shot_consistency_example_str.strip() }}
+```
+
+Begin your JSON output now:

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ rich==14.0.0
 spacy==3.8.7
 structlog>=24.1.0,<25.0.0 # Added structlog
 tiktoken==0.9.0
+jinja2>=3.1,<4
 
 # Development & Testing Dependencies
 flake8==7.0.0

--- a/tests/test_agent_extract.py
+++ b/tests/test_agent_extract.py
@@ -21,9 +21,7 @@ def test_extract_and_merge(monkeypatch):
         "_llm_extract_updates",
         lambda props, text, num: llm_service_mock.async_call_llm(),
     )
-    monkeypatch.setattr(
-        agent, "persist_profiles", lambda profiles: asyncio.sleep(0)
-    )
+    monkeypatch.setattr(agent, "persist_profiles", lambda profiles: asyncio.sleep(0))
     monkeypatch.setattr(agent, "persist_world", lambda world: asyncio.sleep(0))
     monkeypatch.setattr(
         "data_access.kg_queries.add_kg_triples_batch_to_db",

--- a/tests/test_character_labeling.py
+++ b/tests/test_character_labeling.py
@@ -142,10 +142,8 @@ async def test_add_entities_with_character_labeling(mock_neo4j_manager):
     for query, params in captured_statements_for_tests:
         if params.get("subject_name_param") == "Alice":
             assert (
-                "MERGE (s:Character:Entity {name: $subject_name_param})"
-                in query
-                or "MERGE (s:Character:Entity {name: $subject_name_param})"
-                in query
+                "MERGE (s:Character:Entity {name: $subject_name_param})" in query
+                or "MERGE (s:Character:Entity {name: $subject_name_param})" in query
             )  # Accommodate slight variations if any
             alice_statement_found = True
             break
@@ -158,8 +156,7 @@ async def test_add_entities_with_character_labeling(mock_neo4j_manager):
     for query, params in captured_statements_for_tests:
         if params.get("subject_name_param") == "Bob":
             assert (
-                "MERGE (s:Character:Person:Entity {name: $subject_name_param})"
-                in query
+                "MERGE (s:Character:Person:Entity {name: $subject_name_param})" in query
                 or "MERGE (s:Character:Person:Entity {name: $subject_name_param})"
                 in query
             )
@@ -173,10 +170,7 @@ async def test_add_entities_with_character_labeling(mock_neo4j_manager):
     castle_statement_found = False
     for query, params in captured_statements_for_tests:
         if params.get("subject_name_param") == "Castle":
-            assert (
-                "MERGE (s:Location:Entity {name: $subject_name_param})"
-                in query
-            )
+            assert "MERGE (s:Location:Entity {name: $subject_name_param})" in query
             castle_statement_found = True
             break
     assert castle_statement_found, (
@@ -187,10 +181,7 @@ async def test_add_entities_with_character_labeling(mock_neo4j_manager):
     charles_statement_found = False
     for query, params in captured_statements_for_tests:
         if params.get("object_name_param") == "Charles":
-            assert (
-                "MERGE (o:Character:Entity {name: $object_name_param})"
-                in query
-            )
+            assert "MERGE (o:Character:Entity {name: $object_name_param})" in query
             charles_statement_found = True
             break
     assert charles_statement_found, (
@@ -202,8 +193,7 @@ async def test_add_entities_with_character_labeling(mock_neo4j_manager):
     for query, params in captured_statements_for_tests:
         if params.get("object_name_param") == "Diana":
             assert (
-                "MERGE (o:Character:Person:Entity {name: $object_name_param})"
-                in query
+                "MERGE (o:Character:Person:Entity {name: $object_name_param})" in query
             )
             diana_statement_found = True
             break

--- a/tests/test_initial_setup_logic.py
+++ b/tests/test_initial_setup_logic.py
@@ -69,10 +69,7 @@ async def test_valid_json_output_from_llm(agent_instance):
         await generate_world_building_logic(agent_instance)
 
     wb = agent_instance.world_building
-    assert (
-        wb["_overview_"]["description"]
-        == "A vast desert planet with twin suns."
-    )
+    assert wb["_overview_"]["description"] == "A vast desert planet with twin suns."
     assert wb["_overview_"]["mood"] == "Harsh and unforgiving"
 
     assert "Oasis City" in wb["locations"]
@@ -104,7 +101,9 @@ async def test_valid_json_output_from_llm(agent_instance):
 @pytest.mark.asyncio
 async def test_invalid_json_output_decode_error(agent_instance):
     """Test handling of JSONDecodeError when LLM output is malformed."""
-    malformed_json_str = '{"overview": {"description": "A broken world..."'  # Missing closing brace
+    malformed_json_str = (
+        '{"overview": {"description": "A broken world..."'  # Missing closing brace
+    )
     mock_llm_output = (
         malformed_json_str,
         {"prompt_tokens": 5, "completion_tokens": 10, "total_tokens": 15},
@@ -309,9 +308,7 @@ async def test_existing_user_data_preserved_and_llm_fills_gaps(agent_instance):
             "User Keep": {
                 "description": "LLM tries to change this.",  # Should be ignored
                 "atmosphere": "LLM tries to change this too.",  # Should be ignored
-                "features": [
-                    "New LLM feature"
-                ],  # This is a new field, should be added
+                "features": ["New LLM feature"],  # This is a new field, should be added
             },
             "LLM Lava Caves": {
                 "description": "Dangerous lava caves from LLM.",
@@ -343,16 +340,13 @@ async def test_existing_user_data_preserved_and_llm_fills_gaps(agent_instance):
     wb = agent_instance.world_building
 
     # Overview: User's description preserved, LLM's mood used for [Fill-in]
-    assert (
-        wb["_overview_"]["description"] == "User's original world description."
-    )
+    assert wb["_overview_"]["description"] == "User's original world description."
     assert wb["_overview_"]["mood"] == "Mystical and vibrant (from LLM)"
 
     # Locations: User Keep's original details preserved, new field 'features' added by LLM
     assert "User Keep" in wb["locations"]
     assert (
-        wb["locations"]["User Keep"]["description"]
-        == "A sturdy keep from user data."
+        wb["locations"]["User Keep"]["description"] == "A sturdy keep from user data."
     )
     assert wb["locations"]["User Keep"]["atmosphere"] == "Ancient and strong"
     assert wb["locations"]["User Keep"]["features"] == ["New LLM feature"]
@@ -446,9 +440,7 @@ async def test_generate_world_building_mixed_llm_output_format(agent_instance):
     # "overall_vibe", "non_list_property_for_default", "unnormalized_default_prop"
 
     # Create a combined list for patching, ensuring no duplicates and preserving originals
-    mock_list_keys_content = list(
-        set(original_list_keys + test_specific_list_keys)
-    )
+    mock_list_keys_content = list(set(original_list_keys + test_specific_list_keys))
 
     # Patch the global list within the 'initial_setup_logic' module for the duration of this test
     with (
@@ -522,9 +514,7 @@ async def test_generate_world_building_mixed_llm_output_format(agent_instance):
         "text": "A library lost to the depths, holding ancient secrets."
     }
     # 'atmosphere' is not in WORLD_DETAIL_LIST_INTERNAL_KEYS
-    assert sunken_library.get("atmosphere") == {
-        "text": "Mysterious and silent"
-    }
+    assert sunken_library.get("atmosphere") == {"text": "Mysterious and silent"}
 
     # --- Proper Item Asserts ("Dragon's Peak") ---
     assert "Dragon's Peak" in lore_category_data

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -57,9 +57,7 @@ def test_parse_character_updates_simple_json():
 def test_parse_character_updates_empty_or_invalid_json():
     assert parse_unified_character_updates("", 1) == {}
     assert parse_unified_character_updates("{}", 1) == {}
-    assert (
-        parse_unified_character_updates("[]", 1) == {}
-    )  # Not a dict of characters
+    assert parse_unified_character_updates("[]", 1) == {}  # Not a dict of characters
     assert parse_unified_character_updates("invalid json", 1) == {}
     # Test with a valid JSON but not the expected structure (e.g. list at root)
     assert parse_unified_character_updates('[{"name": "Alice"}]', 1) == {}
@@ -128,9 +126,7 @@ def test_parse_world_updates_simple_json():
 
     assert "Overview" in result
     overview_cat = result["Overview"]
-    assert (
-        "_overview_" in overview_cat
-    )  # Overview item is stored with key "_overview_"
+    assert "_overview_" in overview_cat  # Overview item is stored with key "_overview_"
     overview_item = overview_cat["_overview_"]
     assert isinstance(overview_item, WorldItem)
     assert overview_item.category == "Overview"  # Category name from JSON
@@ -146,15 +142,10 @@ def test_parse_world_updates_simple_json():
 def test_parse_world_updates_empty_or_invalid_json():
     assert parse_unified_world_updates("", 1) == {}
     assert parse_unified_world_updates("{}", 1) == {}
-    assert (
-        parse_unified_world_updates("[]", 1) == {}
-    )  # Not a dict of categories
+    assert parse_unified_world_updates("[]", 1) == {}  # Not a dict of categories
     assert parse_unified_world_updates("invalid json", 1) == {}
     # Test with valid JSON but not expected structure (e.g. category content is not a dict of items)
-    assert (
-        parse_unified_world_updates('{"Locations": ["City1", "City2"]}', 1)
-        == {}
-    )
+    assert parse_unified_world_updates('{"Locations": ["City1", "City2"]}', 1) == {}
 
 
 # It might be good to add more tests:

--- a/tests/test_parsing_utils.py
+++ b/tests/test_parsing_utils.py
@@ -43,8 +43,7 @@ class TestRdfTripleParsing(unittest.TestCase):
             (
                 t
                 for t in parsed_triples
-                if t["subject"]["name"] == "Jax"
-                and t["predicate"] == "hasAlias"
+                if t["subject"]["name"] == "Jax" and t["predicate"] == "hasAlias"
             ),
             None,
         )
@@ -62,14 +61,11 @@ class TestRdfTripleParsing(unittest.TestCase):
             (
                 t
                 for t in parsed_triples
-                if t["subject"]["name"] == "Jax"
-                and t["predicate"] == "livesIn"
+                if t["subject"]["name"] == "Jax" and t["predicate"] == "livesIn"
             ),
             None,
         )
-        self.assertIsNotNone(
-            jax_livesin_triple, "Jax livesIn triple not found"
-        )
+        self.assertIsNotNone(jax_livesin_triple, "Jax livesIn triple not found")
         if jax_livesin_triple:
             self.assertFalse(jax_livesin_triple["is_literal_object"])
             self.assertIsNotNone(jax_livesin_triple["object_entity"])
@@ -92,9 +88,7 @@ class TestRdfTripleParsing(unittest.TestCase):
             ),
             None,
         )
-        self.assertIsNotNone(
-            jax_type_triple, "Jax rdf:type Character triple not found"
-        )
+        self.assertIsNotNone(jax_type_triple, "Jax rdf:type Character triple not found")
 
         lila_type_triple = next(
             (
@@ -115,7 +109,9 @@ class TestRdfTripleParsing(unittest.TestCase):
         self.assertEqual(len(parsed_triples), 0)
 
     def test_invalid_turtle(self):
-        invalid_turtle = r"@prefix : <http://example.org/saga/> . char:Jax prop:hasAlias 'J.X.'"
+        invalid_turtle = (
+            r"@prefix : <http://example.org/saga/> . char:Jax prop:hasAlias 'J.X.'"
+        )
         parsed_triples = parse_rdf_triples_with_rdflib(
             invalid_turtle, rdf_format="turtle"
         )

--- a/tests/test_yaml_parser.py
+++ b/tests/test_yaml_parser.py
@@ -20,9 +20,7 @@ class TestYamlParsing(unittest.TestCase):
         with open(self.valid_yaml_filepath, "w", encoding="utf-8") as f:
             yaml.dump(self.valid_yaml_content, f)
 
-        self.malformed_yaml_filepath = os.path.join(
-            self.test_dir, "malformed.yaml"
-        )
+        self.malformed_yaml_filepath = os.path.join(self.test_dir, "malformed.yaml")
         with open(self.malformed_yaml_filepath, "w", encoding="utf-8") as f:
             f.write(
                 "Novel Concept: Title: Test Novel\nGenre: [Sci-Fi"
@@ -35,9 +33,7 @@ class TestYamlParsing(unittest.TestCase):
         self.non_dict_root_yaml_filepath = os.path.join(
             self.test_dir, "non_dict_root.yaml"
         )
-        with open(
-            self.non_dict_root_yaml_filepath, "w", encoding="utf-8"
-        ) as f:
+        with open(self.non_dict_root_yaml_filepath, "w", encoding="utf-8") as f:
             f.write("- item1\n- item2")  # Root is a list
 
     def tearDown(self):
@@ -77,9 +73,7 @@ class TestYamlParsing(unittest.TestCase):
 
     def test_load_empty_yaml(self):
         data = load_yaml_file(self.empty_yaml_filepath)
-        self.assertEqual(
-            data, {}
-        )  # Expecting an empty dictionary for an empty file
+        self.assertEqual(data, {})  # Expecting an empty dictionary for an empty file
 
     def test_load_non_dict_root_yaml(self):
         # Current implementation of load_yaml_file logs error and returns None if root is not dict


### PR DESCRIPTION
## Summary
- add Jinja2 to requirements
- introduce generic prompt renderer
- template DraftingAgent chapter prompt with Jinja2

## Testing
- `ruff check .`
- `ruff format --check .` *(fails: would reformat several test files)*
- `pytest tests/ -v --cov=. --cov-report=term-missing` *(fails: unrecognized arguments)*
- `mypy .` *(fails: found errors in 14 files)*

------
https://chatgpt.com/codex/tasks/task_e_68438e7ccc20832f88f3ae63f4744f3e