### PR TITLE
Refactor orchestrator to use dataclass state

### DIFF
--- a/context_generation_logic.py
+++ b/context_generation_logic.py
@@ -60,13 +60,20 @@ async def _generate_semantic_chapter_context_logic(
         f"Retrieving and constructing SEMANTIC context for Chapter {current_chapter_number} via Neo4j vector search..."
     )
 
-    plot_outline_data = agent_or_props.get(
-        "plot_outline_full", agent_or_props.get("plot_outline", {})
-    )
+    if isinstance(agent_or_props, dict):
+        plot_outline_data = agent_or_props.get(
+            "plot_outline_full", agent_or_props.get("plot_outline", {})
+        )
+    else:
+        plot_outline_data = getattr(agent_or_props, "plot_outline_full", None)
+        if not plot_outline_data:
+            plot_outline_data = getattr(agent_or_props, "plot_outline", {})
 
     plot_points = []
     if isinstance(plot_outline_data, dict):
         plot_points = plot_outline_data.get("plot_points", [])
+    else:
+        plot_points = getattr(plot_outline_data, "plot_points", [])
 
     plot_point_focus = None
     if plot_points and isinstance(plot_points, list) and current_chapter_number > 0:

--- a/drafting_agent.py
+++ b/drafting_agent.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import config
 from llm_interface import count_tokens, llm_service
 from prompt_renderer import render_prompt
-from kg_maintainer.models import SceneDetail
+from kg_maintainer.models import CharacterProfile, SceneDetail, WorldItem
 from utils import format_scene_plan_for_prompt
 
 logger = logging.getLogger(__name__)
@@ -18,7 +18,9 @@ class DraftingAgent:
 
     async def draft_chapter(
         self,
-        novel_props: Dict[str, Any],
+        plot_outline: Dict[str, Any],
+        character_profiles: Dict[str, CharacterProfile],
+        world_building: Dict[str, Dict[str, WorldItem]],
         chapter_number: int,
         plot_point_focus: str,
         hybrid_context_for_draft: str,
@@ -30,12 +32,12 @@ class DraftingAgent:
         """
         logger.info(f"DraftingAgent: Generating draft for Chapter {chapter_number}...")
 
-        protagonist_name = novel_props.get(
+        protagonist_name = plot_outline.get(
             "protagonist_name", config.DEFAULT_PROTAGONIST_NAME
         )
-        novel_title = novel_props.get("title", "Untitled Novel")
-        novel_genre = novel_props.get("genre", "Unknown Genre")
-        novel_theme = novel_props.get("theme", "Unknown Theme")
+        novel_title = plot_outline.get("title", "Untitled Novel")
+        novel_genre = plot_outline.get("genre", "Unknown Genre")
+        novel_theme = plot_outline.get("theme", "Unknown Theme")
 
         # Prepare the scene plan part of the prompt
         # Max tokens for scene plan in prompt can be a fraction of total context, e.g., 1/4th

--- a/kg_maintainer_agent.py
+++ b/kg_maintainer_agent.py
@@ -115,6 +115,8 @@ class KGMaintainerAgent:
         statements: List[Tuple[str, Dict[str, Any]]] = []
         count = 0
         for category_items in world_items_to_persist.values():
+            if not isinstance(category_items, dict):
+                continue
             for item_obj in category_items.values():
                 # Pass chapter_number_for_delta for context
                 statements.extend(

--- a/prompt_data_getters.py
+++ b/prompt_data_getters.py
@@ -509,12 +509,17 @@ async def _get_character_profiles_dict_with_notes(
         return {}
     for char_name, profile_original in character_profiles_data.items():
         if not isinstance(profile_original, dict):
-            logger.warning(
-                f"Character profile for '{char_name}' is not a dict. Skipping."
-            )
-            continue
+            if hasattr(profile_original, "to_dict"):
+                profile_dict = profile_original.to_dict()
+            else:
+                logger.warning(
+                    f"Character profile for '{char_name}' is not a dict. Skipping."
+                )
+                continue
+        else:
+            profile_dict = profile_original
         processed_profiles[char_name] = _add_provisional_notes_and_filter_developments(
-            profile_original, filter_chapter, is_character=True
+            profile_dict, filter_chapter, is_character=True
         )
     return processed_profiles
 
@@ -573,11 +578,14 @@ async def _get_world_data_dict_with_notes(
             "source",
             "user_supplied_data",
         ]:
-            logger.warning(
-                f"World category '{category_name}' content is not a dict (type: {type(category_items_original)}). Skipping formatting."
-            )
-            processed_world_data[category_name] = {}
-            continue
+            if hasattr(category_items_original, "to_dict"):
+                category_items_original = category_items_original.to_dict()
+            else:
+                logger.warning(
+                    f"World category '{category_name}' content is not a dict (type: {type(category_items_original)}). Skipping formatting."
+                )
+                processed_world_data[category_name] = {}
+                continue
         if category_name in ["is_default", "source", "user_supplied_data"]:
             processed_world_data[category_name] = category_items_original
             continue
@@ -590,13 +598,18 @@ async def _get_world_data_dict_with_notes(
         else:
             for item_name, item_data_original in category_items_original.items():
                 if not isinstance(item_data_original, dict):
-                    logger.warning(
-                        f"World item '{item_name}' in category '{category_name}' is not a dict. Skipping."
-                    )
-                    continue
+                    if hasattr(item_data_original, "to_dict"):
+                        item_dict = item_data_original.to_dict()
+                    else:
+                        logger.warning(
+                            f"World item '{item_name}' in category '{category_name}' is not a dict. Skipping."
+                        )
+                        continue
+                else:
+                    item_dict = item_data_original
                 processed_category[item_name] = (
                     _add_provisional_notes_and_filter_developments(
-                        item_data_original, filter_chapter, is_character=False
+                        item_dict, filter_chapter, is_character=False
                     )
                 )
         processed_world_data[category_name] = processed_category

--- a/tests/test_agent_extract.py
+++ b/tests/test_agent_extract.py
@@ -1,6 +1,7 @@
 import asyncio
 
 from kg_maintainer_agent import KGMaintainerAgent
+from kg_maintainer.models import CharacterProfile
 
 
 class DummyLLM:
@@ -28,11 +29,18 @@ def test_extract_and_merge(monkeypatch):
         lambda triples: asyncio.sleep(0),
     )
 
-    props = {
-        "character_profiles": {"Alice": {"description": "Old"}},
-        "world_building": {},
-    }
+    plot_outline = {}
+    character_profiles = {"Alice": CharacterProfile(name="Alice", description="Old")}
+    world_building = {}
 
-    usage = asyncio.run(agent.extract_and_merge_knowledge(props, 1, "text"))
+    usage = asyncio.run(
+        agent.extract_and_merge_knowledge(
+            plot_outline,
+            character_profiles,
+            world_building,
+            1,
+            "text",
+        )
+    )
     assert usage == {"total_tokens": 10}
-    assert props["character_profiles"]["Alice"]["traits"] == ["brave"]
+    assert character_profiles["Alice"].traits == ["brave"]

--- a/tests/test_agent_extract.py
+++ b/tests/test_agent_extract.py
@@ -22,8 +22,10 @@ def test_extract_and_merge(monkeypatch):
         "_llm_extract_updates",
         lambda props, text, num: llm_service_mock.async_call_llm(),
     )
-    monkeypatch.setattr(agent, "persist_profiles", lambda profiles: asyncio.sleep(0))
-    monkeypatch.setattr(agent, "persist_world", lambda world: asyncio.sleep(0))
+    monkeypatch.setattr(
+        agent, "persist_profiles", lambda profiles, chapter: asyncio.sleep(0)
+    )
+    monkeypatch.setattr(agent, "persist_world", lambda world, chapter: asyncio.sleep(0))
     monkeypatch.setattr(
         "data_access.kg_queries.add_kg_triples_batch_to_db",
         lambda triples: asyncio.sleep(0),


### PR DESCRIPTION
## Summary
- ensure orchestrator stores CharacterProfile and WorldItem objects
- pass dataclass structures directly to all agents
- adjust agents to accept plot outline, character profiles and world data
- update async init to convert dictionaries from DB to dataclasses
- modify extract tests for new API

## Testing
- `ruff check . && ruff format --check .`
- `mypy .` *(fails: Found 31 errors)*
- `pytest tests/ -v --cov=. --cov-report=term-missing` *(fails: 8 failed, 28 passed, 10 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6843ab0d0a40832fb9d4edf4a4d21dee