### PR TITLE
Refactor prompt helpers for typed args

### DIFF
--- a/chapter_drafting_logic.py
+++ b/chapter_drafting_logic.py
@@ -5,11 +5,15 @@ Context data for prompts is now formatted as plain text.
 """
 
 import logging
-from typing import Tuple, Optional, List
+from typing import Dict, List, Optional, Tuple
 
 import config
 from llm_interface import llm_service
-from kg_maintainer.models import SceneDetail
+from kg_maintainer.models import (
+    CharacterProfile,
+    SceneDetail,
+    WorldItem,
+)
 import utils
 
 # No direct state_manager import needed here as orchestrator passes data
@@ -35,16 +39,16 @@ def _format_scene_plan_for_prompt(
 
 
 async def generate_chapter_draft_logic(
-    agent,
+    plot_outline: Dict[str, Any],
+    character_profiles: Dict[str, CharacterProfile],
+    world_building: Dict[str, Dict[str, WorldItem]],
     chapter_number: int,
     plot_point_focus: Optional[str],
     hybrid_context: str,
     chapter_plan: Optional[List[SceneDetail]],
 ) -> Tuple[Optional[str], Optional[str]]:
     """Generates the initial draft text for a chapter using HYBRID CONTEXT.
-    Context data and scene plan are now formatted as plain text.
-    'agent' here refers to the orchestrator or an object holding
-    plot_outline etc.
+    Context data and scene plan are formatted as plain text.
     """
     if not plot_point_focus:
         plot_point_focus = (
@@ -89,19 +93,15 @@ async def generate_chapter_draft_logic(
 
     char_profiles_plain_text = (
         await get_filtered_character_profiles_for_prompt_plain_text(
-            agent, chapter_number - 1
+            character_profiles, chapter_number - 1
         )
     )
     world_building_plain_text = await get_filtered_world_data_for_prompt_plain_text(
-        agent,
+        world_building,
         chapter_number - 1,
     )
 
-    plot_outline_data = getattr(
-        agent,
-        "plot_outline",
-        agent.get("plot_outline_full", agent.get("plot_outline", {})),
-    )
+    plot_outline_data = plot_outline
 
     prompt_lines = []
     if config.ENABLE_LLM_NO_THINK_DIRECTIVE:

--- a/comprehensive_evaluator_agent.py
+++ b/comprehensive_evaluator_agent.py
@@ -1,7 +1,6 @@
 # comprehensive_evaluator_agent.py
 import logging
 from typing import Any, Dict, List, Optional, Tuple
-from types import SimpleNamespace
 
 import config
 from llm_interface import llm_service  # MODIFIED
@@ -255,22 +254,16 @@ class ComprehensiveEvaluatorAgent:
         # novel_theme_str, novel_genre_str, protagonist_arc_str removed
         protagonist_name_str = plot_outline.get("protagonist_name", "The Protagonist")
 
-        props = SimpleNamespace(
-            plot_outline=plot_outline,
-            character_profiles=character_profiles,
-            world_building=world_building,
-        )
-
         char_profiles_plain_text = (
             await get_filtered_character_profiles_for_prompt_plain_text(
-                props, chapter_number - 1
+                character_profiles, chapter_number - 1
             )
         )
         world_building_plain_text = await get_filtered_world_data_for_prompt_plain_text(
-            props, chapter_number - 1
+            world_building, chapter_number - 1
         )
         kg_check_results_text = await get_reliable_kg_facts_for_drafting_prompt(
-            props, chapter_number, None
+            plot_outline, chapter_number, None
         )
 
         plot_points_summary_lines = (

--- a/context_generation_logic.py
+++ b/context_generation_logic.py
@@ -308,8 +308,17 @@ async def generate_hybrid_chapter_context_logic(
     semantic_context_task = _generate_semantic_chapter_context_logic(
         agent_or_props, current_chapter_number
     )
+    if isinstance(agent_or_props, dict):
+        plot_outline_data = agent_or_props.get(
+            "plot_outline_full", agent_or_props.get("plot_outline", {})
+        )
+    else:
+        plot_outline_data = getattr(agent_or_props, "plot_outline_full", None)
+        if not plot_outline_data:
+            plot_outline_data = getattr(agent_or_props, "plot_outline", {})
+
     kg_facts_task = get_reliable_kg_facts_for_drafting_prompt(
-        agent_or_props, current_chapter_number, chapter_plan
+        plot_outline_data, current_chapter_number, chapter_plan
     )
 
     semantic_context_str, kg_facts_str = await asyncio.gather(

--- a/nana_orchestrator.py
+++ b/nana_orchestrator.py
@@ -857,7 +857,9 @@ class NANA_Orchestrator:
                     revision_tuple_result,
                     revision_usage,
                 ) = await revise_chapter_draft_logic(
-                    self,
+                    self.plot_outline,
+                    self.character_profiles,
+                    self.world_building,
                     current_text_to_process,
                     novel_chapter_number,
                     evaluation_result,

--- a/planner_agent.py
+++ b/planner_agent.py
@@ -3,7 +3,6 @@
 import json  # Added for JSON parsing
 import logging
 import re
-from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Tuple
 
 import config
@@ -222,19 +221,16 @@ class PlannerAgent:
         protagonist_name = plot_outline.get(
             "protagonist_name", config.DEFAULT_PROTAGONIST_NAME
         )
-        props = SimpleNamespace(
-            plot_outline=plot_outline,
-            character_profiles=character_profiles,
-            world_building=world_building,
-        )
         kg_context_section = await get_reliable_kg_facts_for_drafting_prompt(
-            props, chapter_number, None
+            plot_outline, chapter_number, None
         )
         character_state_snippet_plain_text = (
-            await get_character_state_snippet_for_prompt(props, chapter_number)
+            await get_character_state_snippet_for_prompt(
+                character_profiles, plot_outline, chapter_number
+            )
         )
         world_state_snippet_plain_text = await get_world_state_snippet_for_prompt(
-            props, chapter_number
+            world_building, chapter_number
         )
 
         future_plot_context_parts: List[str] = []

--- a/world_continuity_agent.py
+++ b/world_continuity_agent.py
@@ -1,7 +1,6 @@
 # world_continuity_agent.py
 import logging
 from typing import Any, Dict, List, Optional, Tuple
-from types import SimpleNamespace
 from kg_maintainer.models import CharacterProfile, ProblemDetail, WorldItem
 
 import config
@@ -244,18 +243,13 @@ class WorldContinuityAgent:
         )
 
         protagonist_name_str = plot_outline.get("protagonist_name", "The Protagonist")
-        props = SimpleNamespace(
-            plot_outline=plot_outline,
-            character_profiles=character_profiles,
-            world_building=world_building,
-        )
         char_profiles_plain_text = (
             await get_filtered_character_profiles_for_prompt_plain_text(
-                props, chapter_number - 1
+                character_profiles, chapter_number - 1
             )
         )
         world_building_plain_text = await get_filtered_world_data_for_prompt_plain_text(
-            props, chapter_number - 1
+            world_building, chapter_number - 1
         )
 
         plot_points_summary_lines = (


### PR DESCRIPTION
## Summary
- refactor prompt helpers to take explicit objects instead of generic agent references
- update chapter revision logic to use typed arguments
- adjust orchestrator and agent modules for new APIs

## Testing
- `ruff check .`
- `ruff format --check prompt_data_getters.py chapter_revision_logic.py planner_agent.py comprehensive_evaluator_agent.py world_continuity_agent.py chapter_drafting_logic.py nana_orchestrator.py context_generation_logic.py`
- `mypy .` *(fails: Library stubs not installed for "yaml" and other typing issues)*
- `pytest tests/ -v --cov=. --cov-report=term-missing` *(fails: unrecognized arguments: --cov=. --cov-report=term-missing)*

------
https://chatgpt.com/codex/tasks/task_e_6843c83009e4832fac85749eb230e97c