### PR TITLE
Refactor chapter generation orchestration

### DIFF
--- a/chapter_drafting_logic.py
+++ b/chapter_drafting_logic.py
@@ -5,16 +5,16 @@ Context data for prompts is now formatted as plain text.
 """
 
 import logging
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import config
-from llm_interface import llm_service
+import utils
 from kg_maintainer.models import (
     CharacterProfile,
     SceneDetail,
     WorldItem,
 )
-import utils
+from llm_interface import llm_service
 
 # No direct state_manager import needed here as orchestrator passes data
 from prompt_data_getters import (

--- a/tests/test_orchestrator_private_methods.py
+++ b/tests/test_orchestrator_private_methods.py
@@ -1,0 +1,60 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+import utils
+from nana_orchestrator import NANA_Orchestrator
+
+
+@pytest.fixture
+def orchestrator(monkeypatch):
+    monkeypatch.setattr(utils, "load_spacy_model_if_needed", lambda: None)
+    orch = NANA_Orchestrator()
+    monkeypatch.setattr(orch, "_update_rich_display", lambda *a, **k: None)
+    return orch
+
+
+@pytest.mark.asyncio
+async def test_validate_plot_outline_missing(orchestrator):
+    orchestrator.plot_outline = {}
+    assert not await orchestrator._validate_plot_outline(1)
+
+
+@pytest.mark.asyncio
+async def test_process_prereq_result_failure(orchestrator):
+    result = await orchestrator._process_prereq_result(1, (None, -1, None, None))
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_process_initial_draft_failure(orchestrator):
+    result = await orchestrator._process_initial_draft(1, (None, None))
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_process_revision_result_failure(orchestrator):
+    result = await orchestrator._process_revision_result(1, (None, None, False))
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_finalize_and_log_success(orchestrator, monkeypatch):
+    monkeypatch.setattr(
+        orchestrator,
+        "_finalize_and_save_chapter",
+        AsyncMock(return_value="final"),
+    )
+    result = await orchestrator._finalize_and_log(1, "text", None, False)
+    assert result == "final"
+
+
+@pytest.mark.asyncio
+async def test_finalize_and_log_failure(orchestrator, monkeypatch):
+    monkeypatch.setattr(
+        orchestrator,
+        "_finalize_and_save_chapter",
+        AsyncMock(return_value=None),
+    )
+    result = await orchestrator._finalize_and_log(1, "text", None, True)
+    assert result is None


### PR DESCRIPTION
## Summary
- modularize steps in `run_chapter_generation_process` into helper methods
- add unit tests for new helper methods
- fix missing `Any` import

## Testing
- `ruff check . && ruff format --check .`
- `pytest tests/ -v --cov=. --cov-report=term-missing` *(fails: tests failing)*
- `mypy .` *(fails: missing YAML stubs)*

------
https://chatgpt.com/codex/tasks/task_e_6843d11f1bf0832fa8c06b509fedd898