### PR TITLE
Improve patch application performance

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -6,8 +6,9 @@ General utility functions for the Saga Novel Generation system.
 import asyncio
 import logging
 import re
-import asyncio
-from typing import TYPE_CHECKING, Any, List, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+
+import numpy as np
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from kg_maintainer.models import SceneDetail


### PR DESCRIPTION
## Summary
- optimize `_apply_patches_to_text` to build new text with slicing
- ensure numpy imported in utils
- expand revision patching tests for multiple segments and duplicates

## Testing
- `ruff check . && ruff format --check .`
- `pytest tests/ -v --cov=. --cov-report=term-missing`
- `mypy .`

------
https://chatgpt.com/codex/tasks/task_e_6849b39558d8832fa2349333a72a9f96