### PR TITLE
Add scene drafting prompt and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ SAGA is an autonomous, agentic creative-writing system designed to generate enti
 SAGA, with its NANA engine, is an ambitious project designed to autonomously craft entire novels. It transcends simple text generation by employing a collaborative team of specialized AI agents:
 
 *   **`PlannerAgent`:** Strategically outlines detailed scene-by-scene plans for each chapter, ensuring plot progression.
-*   **`DraftingAgent`:** Weaves the initial prose for chapters, guided by the `PlannerAgent`'s blueprints and rich contextual information.
+*   **`DraftingAgent`:** Weaves the initial prose for chapters, guided by the `PlannerAgent`'s blueprints and rich contextual information. It uses two Jinja templates: `draft_chapter_from_plot_point.j2` for single-pass chapter drafting and `draft_scene.j2` when generating chapters scene by scene.
 *   **`ComprehensiveEvaluatorAgent`:** Critically assesses drafts for plot coherence, thematic alignment, character consistency, narrative depth, and overall quality.
 *   **`WorldContinuityAgent`:** Performs targeted checks to ensure consistency with established world-building rules, lore, and character backstories within the narrative.
 *   **`ChapterRevisionLogic`:** Implements sophisticated revisions based on evaluation feedback, capable of performing targeted, patch-based fixes or full chapter rewrites.

--- a/drafting_agent.py
+++ b/drafting_agent.py
@@ -3,14 +3,25 @@ import logging
 from typing import Any, Dict, List, Optional, Tuple
 
 import config
+from kg_maintainer.models import CharacterProfile, SceneDetail
 from llm_interface import count_tokens, llm_service, truncate_text_by_tokens
 from prompt_renderer import render_prompt
-from kg_maintainer.models import CharacterProfile, SceneDetail, WorldItem
 
 logger = logging.getLogger(__name__)
 
 
 class DraftingAgent:
+    """Generate initial prose for a chapter using LLMs.
+
+    The agent supports two modes of operation:
+    1. **Whole chapter drafting** when no scene plan is provided.
+    2. **Scene-by-scene drafting** when supplied with a list of ``SceneDetail``
+       objects.
+
+    Both modes return the full draft text, the raw LLM output, and token usage
+    statistics for further processing by the orchestrator.
+    """
+
     def __init__(self, model_name: str = config.DRAFTING_MODEL):
         # We now only need a single, capable model for drafting.
         self.drafting_model = model_name
@@ -22,7 +33,6 @@ class DraftingAgent:
         self,
         plot_outline: Dict[str, Any],
         character_profiles: Dict[str, CharacterProfile],
-        world_building: Dict[str, Dict[str, WorldItem]],
         chapter_number: int,
         plot_point_focus: str,
         hybrid_context_for_draft: str,
@@ -30,9 +40,13 @@ class DraftingAgent:
     ) -> Tuple[Optional[str], Optional[str], Optional[Dict[str, int]]]:
         """
         Generates the initial draft for a chapter.
-        If a chapter_plan is provided, it drafts scene-by-scene.
-        If chapter_plan is None, it drafts the entire chapter from the plot_point_focus.
-        Returns: (draft_text, raw_llm_output, usage_data)
+
+        If ``chapter_plan`` is provided, each scene is drafted sequentially and
+        concatenated. When ``chapter_plan`` is ``None`` the entire chapter is
+        drafted in a single LLM call using the provided ``plot_point_focus``.
+
+        Returns:
+            Tuple of the draft text, the raw LLM output, and token usage data.
         """
         if not chapter_plan:
             # --- WHOLE CHAPTER DRAFTING LOGIC (NO SCENE PLAN) ---

--- a/nana_orchestrator.py
+++ b/nana_orchestrator.py
@@ -634,7 +634,6 @@ class NANA_Orchestrator:
         ) = await self.drafting_agent.draft_chapter(
             self.plot_outline,
             self.character_profiles,
-            self.world_building,
             novel_chapter_number,
             plot_point_focus,
             hybrid_context_for_draft,

--- a/prompts/drafting_agent/draft_scene.j2
+++ b/prompts/drafting_agent/draft_scene.j2
@@ -1,0 +1,30 @@
+/no_think
+
+You are an expert novelist tasked with writing a single scene.
+
+**Novel Details:**
+- Title: {{ novel_title }}
+- Genre: {{ novel_genre }}
+
+**Chapter & Scene Focus:**
+- Chapter Number: {{ chapter_number }}
+- Scene Number: {{ scene_detail.scene_number }}
+- Scene Summary: "{{ scene_detail.summary }}"
+
+**Hybrid Context (for canonical consistency):**
+--- BEGIN HYBRID CONTEXT ---
+{{ hybrid_context_for_draft }}
+--- END HYBRID CONTEXT ---
+
+**Prior Scene Prose (for continuity within this chapter):**
+--- BEGIN PRIOR SCENES ---
+{{ previous_scenes_prose }}
+--- END PRIOR SCENES ---
+
+**Instructions:**
+1. Write the narrative prose for this scene only. Do not include headings or meta-commentary.
+2. Ensure the prose aligns with the Hybrid Context and Prior Scene Prose.
+3. Aim for at least {{ min_length_per_scene }} characters of text.
+4. Output ONLY the scene text.
+
+--- BEGIN SCENE {{ scene_detail.scene_number }} TEXT ---

--- a/tests/test_drafting_agent.py
+++ b/tests/test_drafting_agent.py
@@ -1,0 +1,61 @@
+import pytest
+
+from drafting_agent import DraftingAgent
+from kg_maintainer.models import SceneDetail
+from llm_interface import llm_service
+
+
+@pytest.mark.asyncio
+async def test_draft_chapter_whole_chapter(monkeypatch):
+    agent = DraftingAgent()
+
+    async def fake_call_llm(**kwargs):
+        return "chapter text", {"total_tokens": 5}
+
+    monkeypatch.setattr(llm_service, "async_call_llm", fake_call_llm)
+
+    plot_outline = {"title": "Test", "genre": "F"}
+    draft, raw, usage = await agent.draft_chapter(
+        plot_outline,
+        {},
+        1,
+        "focus",
+        "context",
+        None,
+    )
+
+    assert draft == "chapter text"
+    assert raw == "chapter text"
+    assert usage == {"total_tokens": 5}
+
+
+@pytest.mark.asyncio
+async def test_draft_chapter_scene_mode(monkeypatch):
+    agent = DraftingAgent()
+    responses = [
+        ("scene1", {"prompt_tokens": 1}),
+        ("scene2", {"prompt_tokens": 1}),
+    ]
+
+    async def fake_call_llm(**kwargs):
+        return responses.pop(0)
+
+    monkeypatch.setattr(llm_service, "async_call_llm", fake_call_llm)
+
+    scenes = [
+        SceneDetail(scene_number=1, summary="a"),
+        SceneDetail(scene_number=2, summary="b"),
+    ]
+
+    draft, raw, usage = await agent.draft_chapter(
+        {"title": "Test", "genre": "F"},
+        {},
+        2,
+        "focus",
+        "context",
+        scenes,
+    )
+
+    assert draft == "scene1\n\nscene2"
+    assert "scene1" in raw and "scene2" in raw
+    assert usage["prompt_tokens"] == 2


### PR DESCRIPTION
## Summary
- add template for drafting scenes
- document DraftingAgent usage and new template
- remove unused `world_building` parameter
- update orchestrator call to DraftingAgent
- test DraftingAgent in whole-chapter and scene modes

## Testing
- `ruff check .`
- `pytest tests/ -v --cov=. --cov-report=term-missing`
- `mypy drafting_agent.py nana_orchestrator.py` *(fails: Library stubs not installed for "yaml" and many other errors)*

------
https://chatgpt.com/codex/tasks/task_e_684da41b81d0832f957c4f53070c6541