### PR TITLE
Improve deduplication and add problem parsing tests

### DIFF
--- a/problem_parser.py
+++ b/problem_parser.py
@@ -1,0 +1,77 @@
+"""Shared utilities for parsing problem lists from LLM JSON output."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import List, Optional
+
+from kg_maintainer.models import ProblemDetail
+
+logger = logging.getLogger(__name__)
+
+
+def parse_problem_list(
+    text: str, category: Optional[str] = None
+) -> List[ProblemDetail]:
+    """Parse a JSON list of problem details.
+
+    Args:
+        text: Raw JSON string from the LLM.
+        category: Optional enforced category for each problem.
+
+    Returns:
+        A list of ``ProblemDetail`` objects. If the JSON is invalid an error
+        entry is returned.
+    """
+    if not text or not text.strip():
+        return []
+    try:
+        data = json.loads(text)
+        if isinstance(data, dict):
+            if "status" in data and "no significant" in data["status"].lower():
+                return []
+            if "problems" in data and isinstance(data["problems"], list):
+                data = data["problems"]
+        if not isinstance(data, list):
+            raise ValueError("LLM output was not a list of problems")
+    except json.JSONDecodeError as exc:
+        logger.error("Failed to decode JSON: %s", exc)
+        return [
+            {
+                "issue_category": category or "meta",
+                "problem_description": f"Invalid JSON from LLM: {exc}",
+                "quote_from_original_text": "N/A - Invalid JSON",
+                "quote_char_start": None,
+                "quote_char_end": None,
+                "sentence_char_start": None,
+                "sentence_char_end": None,
+                "suggested_fix_focus": "Ensure LLM outputs valid JSON.",
+            }
+        ]
+
+    problems: List[ProblemDetail] = []
+    for item in data:
+        if not isinstance(item, dict):
+            logger.warning("Problem item is not a dict: %s", item)
+            continue
+        prob: ProblemDetail = {
+            "issue_category": item.get("issue_category", category or "meta"),
+            "problem_description": item.get(
+                "problem_description", "N/A - Missing description"
+            ),
+            "quote_from_original_text": item.get(
+                "quote_from_original_text", "N/A - General Issue"
+            ),
+            "quote_char_start": None,
+            "quote_char_end": None,
+            "sentence_char_start": None,
+            "sentence_char_end": None,
+            "suggested_fix_focus": item.get(
+                "suggested_fix_focus", "N/A - Missing suggestion"
+            ),
+        }
+        if category:
+            prob["issue_category"] = category
+        problems.append(prob)
+    return problems

--- a/tests/test_evaluation_parsing.py
+++ b/tests/test_evaluation_parsing.py
@@ -1,0 +1,30 @@
+import asyncio
+import pytest
+
+from comprehensive_evaluator_agent import ComprehensiveEvaluatorAgent
+from world_continuity_agent import WorldContinuityAgent
+
+
+@pytest.mark.asyncio
+async def test_eval_agent_parsing_valid(monkeypatch):
+    agent = ComprehensiveEvaluatorAgent()
+    monkeypatch.setattr(
+        agent, "_parse_llm_evaluation_output", agent._parse_llm_evaluation_output
+    )
+    data = '[{"issue_category": "plot_arc", "problem_description": "d", "quote_from_original_text": "q", "suggested_fix_focus": "f"}]'
+    problems = await agent._parse_llm_evaluation_output(data, 1, "text")
+    assert problems[0]["issue_category"] == "plot_arc"
+
+
+@pytest.mark.asyncio
+async def test_eval_agent_parsing_empty():
+    agent = ComprehensiveEvaluatorAgent()
+    result = await agent._parse_llm_evaluation_output("", 1, "text")
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_consistency_agent_parsing_invalid(monkeypatch):
+    agent = WorldContinuityAgent()
+    problems = await agent._parse_llm_consistency_output("notjson", 1, "text")
+    assert problems[0]["issue_category"] == "consistency"

--- a/tests/test_evaluation_parsing.py
+++ b/tests/test_evaluation_parsing.py
@@ -1,4 +1,3 @@
-import asyncio
 import pytest
 
 from comprehensive_evaluator_agent import ComprehensiveEvaluatorAgent

--- a/tests/test_problem_parser.py
+++ b/tests/test_problem_parser.py
@@ -1,0 +1,29 @@
+import json
+import pytest
+from problem_parser import parse_problem_list
+
+
+def test_parse_problem_list_valid():
+    data = json.dumps(
+        [
+            {
+                "issue_category": "consistency",
+                "problem_description": "desc",
+                "quote_from_original_text": "q",
+                "suggested_fix_focus": "fix",
+            }
+        ]
+    )
+    result = parse_problem_list(data)
+    assert len(result) == 1
+    assert result[0]["issue_category"] == "consistency"
+
+
+def test_parse_problem_list_invalid_json():
+    result = parse_problem_list("notjson", category="plot")
+    assert result[0]["issue_category"] == "plot"
+    assert "Invalid JSON" in result[0]["problem_description"]
+
+
+def test_parse_problem_list_empty():
+    assert parse_problem_list("") == []

--- a/tests/test_problem_parser.py
+++ b/tests/test_problem_parser.py
@@ -1,5 +1,4 @@
 import json
-import pytest
 from problem_parser import parse_problem_list
 
 

--- a/text_deduplicator.py
+++ b/text_deduplicator.py
@@ -1,0 +1,125 @@
+"""Utilities for detecting and removing duplicate text segments."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import re
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+import config
+from llm_interface import llm_service
+import utils
+
+logger = logging.getLogger(__name__)
+
+
+class TextDeduplicator:
+    """Detects duplicate text segments using hashing and embeddings."""
+
+    def __init__(
+        self,
+        similarity_threshold: float = config.DEDUPLICATION_SEMANTIC_THRESHOLD,
+        use_semantic_comparison: bool = config.DEDUPLICATION_USE_SEMANTIC,
+        min_segment_length_chars: int = config.DEDUPLICATION_MIN_SEGMENT_LENGTH,
+        prefer_newer: bool = False,
+    ) -> None:
+        self.similarity_threshold = similarity_threshold
+        self.use_semantic_comparison = use_semantic_comparison
+        self.min_segment_length_chars = min_segment_length_chars
+        self.prefer_newer = prefer_newer
+
+    async def deduplicate(
+        self, original_text: str, segment_level: str = "paragraph"
+    ) -> Tuple[str, int]:
+        if not original_text.strip():
+            return original_text, 0
+
+        segments = utils.get_text_segments(original_text, segment_level)
+        if not segments:
+            return original_text, 0
+
+        normalized_cache: List[str] = [
+            utils._normalize_text_for_matching(seg[0]) for seg in segments
+        ]
+        indices_to_remove: set[int] = set()
+        fingerprint_map: Dict[str, int] = {}
+        iteration_range = (
+            range(len(segments) - 1, -1, -1)
+            if self.prefer_newer
+            else range(len(segments))
+        )
+
+        for idx in iteration_range:
+            if idx in indices_to_remove:
+                continue
+            seg_text, _, _ = segments[idx]
+            if len(seg_text) < self.min_segment_length_chars:
+                continue
+            norm = normalized_cache[idx]
+            fingerprint = hashlib.md5(norm.encode()).hexdigest()
+            if fingerprint in fingerprint_map:
+                other_idx = fingerprint_map[fingerprint]
+                remove_idx = idx if not self.prefer_newer else other_idx
+                indices_to_remove.add(remove_idx)
+                if self.prefer_newer:
+                    fingerprint_map[fingerprint] = idx
+                continue
+            fingerprint_map[fingerprint] = idx
+
+        embeddings: List[Optional[np.ndarray]] = [None] * len(segments)
+        if self.use_semantic_comparison:
+            unique_indices = [i for i in iteration_range if i not in indices_to_remove]
+            tasks = [
+                llm_service.async_get_embedding(segments[i][0]) for i in unique_indices
+            ]
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            for idx, result in zip(unique_indices, results):
+                if not isinstance(result, Exception):
+                    embeddings[idx] = result
+
+            keepers: List[int] = []
+            for idx in iteration_range:
+                if idx in indices_to_remove:
+                    continue
+                if embeddings[idx] is None:
+                    keepers.append(idx)
+                    continue
+                is_dup = False
+                for kept_idx in keepers:
+                    emb_j = embeddings[kept_idx]
+                    if emb_j is None:
+                        continue
+                    similarity = utils.numpy_cosine_similarity(embeddings[idx], emb_j)
+                    if similarity > self.similarity_threshold:
+                        remove_idx = idx if not self.prefer_newer else kept_idx
+                        indices_to_remove.add(remove_idx)
+                        if self.prefer_newer and remove_idx == kept_idx:
+                            keepers.remove(kept_idx)
+                            keepers.append(idx)
+                        is_dup = True
+                        break
+                if not is_dup:
+                    keepers.append(idx)
+
+        if not indices_to_remove:
+            return original_text, 0
+
+        spans_to_remove = [segments[i][1:] for i in sorted(indices_to_remove)]
+        spans_to_remove.sort(key=lambda x: x[0])
+        new_parts: List[str] = []
+        last_pos = 0
+        for start, end in spans_to_remove:
+            if start > last_pos:
+                new_parts.append(original_text[last_pos:start])
+            last_pos = max(last_pos, end)
+        if last_pos < len(original_text):
+            new_parts.append(original_text[last_pos:])
+        dedup_text = "".join(new_parts)
+        dedup_text = re.sub(r"\n\s*\n(\s*\n)+", "\n\n", dedup_text)
+        dedup_text = re.sub(r"\n{3,}", "\n\n", dedup_text).strip()
+        removed_count = len(original_text) - len(dedup_text)
+        return dedup_text, removed_count


### PR DESCRIPTION
## Summary
- implement `TextDeduplicator` for faster duplicate removal
- update orchestrator to use the new deduplicator and run after revisions
- add shared `parse_problem_list` utility
- refactor evaluation parser to use shared parser
- add unit tests for problem parsing and evaluation parsing

## Testing
- `ruff check .`
- `ruff format --check .`
- `pytest tests/ -v --cov=. --cov-report=term-missing`
- `mypy .` *(fails: Module has no attribute errors)*

------
https://chatgpt.com/codex/tasks/task_e_684da814e8c4832f8d0c752d92df8869