### PR TITLE
feat(tasks): implement patch validation and embedding remap

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ SAGA, with its NANA engine, is an ambitious project designed to autonomously cra
 *   **`ComprehensiveEvaluatorAgent`:** Critically assesses drafts for plot coherence, thematic alignment, character consistency, narrative depth, and overall quality.
 *   **`WorldContinuityAgent`:** Performs targeted checks to ensure consistency with established world-building rules, lore, and character backstories within the narrative.
 *   **`ChapterRevisionLogic`:** Implements sophisticated revisions based on evaluation feedback, capable of performing targeted, patch-based fixes or full chapter rewrites.
+*   **`PatchValidationAgent`:** Verifies generated patch instructions to ensure they resolve the issues before being applied.
 *   **`KGMaintainerAgent`:** Intelligently manages the novel's evolving knowledge graph in Neo4j. It summarizes chapters, pre-populates the graph with initial story data, and exposes an `extract_and_merge_knowledge` method to parse new chapters and persist updates.
 *   **`kg_maintainer` utilities:** Provide dataclass models and helper functions for parsing, merging, and generating Cypher statements used by `KGMaintainerAgent`.
 
@@ -75,6 +76,7 @@ SAGA's NANA engine orchestrates a sophisticated pipeline for novel generation:
     *   **(D) Revision (if `needs_revision` is true):**
         *   `ChapterRevisionLogic` attempts to fix identified issues.
         *   If `ENABLE_PATCH_BASED_REVISION` is true, it generates and applies targeted text patches for specific problems.
+            See `docs/step5_redesign.md` for a proposed improvement of this phase.
         *   If patching is insufficient or disabled, or problems are extensive, a full chapter rewrite may be performed.
         *   The de-duplication and evaluation steps are repeated on the revised text.
     *   **(E) Finalization & Knowledge Update:**

--- a/docs/step5_redesign.md
+++ b/docs/step5_redesign.md
@@ -1,0 +1,58 @@
+# Proposed Redesign of Phase 2 Step 5: The Renovation
+
+This document proposes a new approach for the patch-based revision step in SAGA.
+The goal is to produce higher quality chapters while keeping the pipeline fast
+and deterministic.
+
+## Current Issues
+
+* **Patch Quality Varies:** Generated patches sometimes fail to correct the
+  identified problem or introduce new inconsistencies.
+* **Overlapping Fixes:** Multiple problems can target the same sentence leading
+  to conflicting patches.
+* **Unclear Validation:** After applying a patch it is not obvious whether the
+  fix resolves the underlying critique.
+
+## Key Changes
+
+1. **Structured Patch Requests**
+   * Problems are grouped by their sentence offsets prior to calling the LLM.
+   * A single request generates patches for an entire group, ensuring coherent
+     changes when multiple issues overlap.
+   * The LLM receives a table summarising all issues for that group along with
+     a snippet of the original text.
+
+2. **Patch Verification Phase**
+   * A lightweight `PatchValidationAgent` reviews each generated patch.
+   * It confirms that the replacement addresses all issues in the group and
+     preserves continuity with the surrounding context.
+   * If validation fails, the patch is discarded and the group is queued for
+     a full rewrite fallback.
+
+3. **Semantic Re-mapping**
+   * Sentence embeddings are stored when the chapter draft is first produced.
+   * When applying a patch, the system uses these embeddings to more reliably
+     locate sentences even if offsets shift during earlier revisions.
+   * This reduces patch drift when multiple cycles occur.
+
+4. **Adaptive Retry Logic**
+   * Each patch group is allowed up to two attempts.
+   * On the first failure the system rewrites the prompt with stricter
+     instructions. On the second failure it escalates to a full rewrite of the
+     affected section.
+
+5. **Metrics and Logging**
+   * Patch generation and validation usage statistics are tracked separately.
+   * Detailed logs make it easier to trace why a patch was discarded or kept.
+
+## Benefits
+
+* **Improved Accuracy:** Grouping related problems and verifying patches reduces
+  the risk of partial fixes.
+* **Better Stability:** Embedding-based sentence mapping ensures patches apply to
+  the correct text even after earlier revisions.
+* **Clearer Failures:** The validation phase explicitly signals when a patch is
+  insufficient, triggering a fallback rather than silently accepting bad output.
+
+This redesign keeps Step 5 aligned with the overall chapter-generation loop while
+making patch-based revision more reliable and transparent.

--- a/patch_validation_agent.py
+++ b/patch_validation_agent.py
@@ -1,0 +1,53 @@
+import logging
+from typing import Dict, List, Optional, Tuple
+
+import config
+from kg_maintainer.models import PatchInstruction, ProblemDetail
+from llm_interface import llm_service
+from prompt_renderer import render_prompt
+
+logger = logging.getLogger(__name__)
+
+
+class PatchValidationAgent:
+    """Validates patch instructions using an LLM."""
+
+    def __init__(self, model_name: str = config.EVALUATION_MODEL) -> None:
+        self.model_name = model_name
+        logger.info("PatchValidationAgent initialized with model: %s", self.model_name)
+
+    async def validate_patch(
+        self,
+        context_snippet: str,
+        patch: PatchInstruction,
+        problems: List[ProblemDetail],
+    ) -> Tuple[bool, Optional[Dict[str, int]]]:
+        """Return True if patch addresses all problems according to the LLM."""
+
+        issues_list = "\n".join(f"- {p['problem_description']}" for p in problems)
+        prompt = render_prompt(
+            "patch_validation_agent/validate_patch.j2",
+            {
+                "context_snippet": context_snippet,
+                "patch_text": patch.get("replace_with", ""),
+                "issues_list": issues_list,
+            },
+        )
+
+        response_text, usage = await llm_service.async_call_llm(
+            model_name=self.model_name,
+            prompt=prompt,
+            temperature=config.Temperatures.EVALUATION,
+            max_tokens=64,
+            allow_fallback=True,
+            stream_to_disk=False,
+            frequency_penalty=config.FREQUENCY_PENALTY_EVALUATION,
+            presence_penalty=config.PRESENCE_PENALTY_EVALUATION,
+            auto_clean_response=True,
+        )
+
+        verdict_line = response_text.splitlines()[0].strip().lower()
+        is_pass = verdict_line.startswith("pass")
+        if not is_pass:
+            logger.info("Patch validation failed: %s", verdict_line)
+        return is_pass, usage

--- a/prompts/patch_validation_agent/validate_patch.j2
+++ b/prompts/patch_validation_agent/validate_patch.j2
@@ -1,0 +1,13 @@
+/no_think
+You are a meticulous editor checking whether a proposed patch resolves all listed issues without harming continuity.
+
+**Context Snippet:**
+{{ context_snippet }}
+
+**Patch Text:**
+{{ patch_text }}
+
+**Issues to Resolve:**
+{{ issues_list }}
+
+Respond with **PASS** if the patch fully resolves the issues. Respond with **FAIL** followed by a brief reason if it does not.

--- a/tests/test_revision_patching.py
+++ b/tests/test_revision_patching.py
@@ -1,9 +1,9 @@
 import numpy as np
 import pytest
 
+import utils
 from chapter_revision_logic import _apply_patches_to_text
 from llm_interface import llm_service
-import utils
 
 
 @pytest.mark.asyncio
@@ -24,7 +24,7 @@ async def test_patch_skipped_when_high_similarity(monkeypatch):
 
     monkeypatch.setattr(llm_service, "async_get_embedding", fake_embed)
 
-    result, _ = await _apply_patches_to_text(original, patches)
+    result, _ = await _apply_patches_to_text(original, patches, None, None)
     assert result == original
 
 
@@ -51,7 +51,7 @@ async def test_patch_applied_when_low_similarity(monkeypatch):
 
     monkeypatch.setattr(llm_service, "async_get_embedding", fake_embed)
 
-    result, _ = await _apply_patches_to_text(original, patches)
+    result, _ = await _apply_patches_to_text(original, patches, None, None)
     assert result == "Hi world!"
 
 
@@ -103,8 +103,8 @@ async def test_skip_repatch_same_segment(monkeypatch):
 
     monkeypatch.setattr(llm_service, "async_get_embedding", fake_embed)
 
-    patched1, spans1 = await _apply_patches_to_text(text, first_patch)
-    patched2, _ = await _apply_patches_to_text(patched1, second_patch, spans1)
+    patched1, spans1 = await _apply_patches_to_text(text, first_patch, None, None)
+    patched2, _ = await _apply_patches_to_text(patched1, second_patch, spans1, None)
 
     assert patched2 == patched1
     dedup, _ = await utils.deduplicate_text_segments(
@@ -149,7 +149,7 @@ async def test_multiple_patches_applied(monkeypatch):
 
     monkeypatch.setattr(llm_service, "async_get_embedding", fake_embed)
 
-    result, _ = await _apply_patches_to_text(original, patches)
+    result, _ = await _apply_patches_to_text(original, patches, None, None)
     assert result == "Hi world! See ya world!"
 
 
@@ -185,6 +185,6 @@ async def test_duplicate_patch_skipped(monkeypatch):
 
     monkeypatch.setattr(llm_service, "async_get_embedding", fake_embed)
 
-    result, _ = await _apply_patches_to_text(original, patches)
+    result, _ = await _apply_patches_to_text(original, patches, None, None)
     # Only the first patch should be applied because the second overlaps exactly
     assert result == "Hi world!"


### PR DESCRIPTION
## Summary
- implement PatchValidationAgent for verifying patch instructions
- improve chapter revision logic with sentence embeddings
- add patch validation prompt
- update tests and docs

## Testing
- `ruff check .` *(passed)*
- `ruff format --check chapter_revision_logic.py patch_validation_agent.py tests/test_revision_patching.py` *(passed)*
- `pytest tests/ -v --cov=. --cov-report=term-missing` *(passed)*
- `mypy patch_validation_agent.py chapter_revision_logic.py` *(failed: 108 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684db87dec88832fa2bd623be7336904