### PR TITLE
Add FinalizeAgent for chapter finalization

### DIFF
--- a/finalize_agent.py
+++ b/finalize_agent.py
@@ -1,0 +1,189 @@
+import asyncio
+import json
+import re
+from typing import Any, Dict, Optional, TypedDict
+
+import numpy as np
+import structlog
+
+from data_access import chapter_queries, kg_queries
+from kg_maintainer.models import CharacterProfile, WorldItem
+from kg_maintainer_agent import KGMaintainerAgent
+from llm_interface import llm_service
+from parsing_utils import parse_rdf_triples_with_rdflib
+
+logger = structlog.get_logger(__name__)
+
+
+class FinalizationResult(TypedDict, total=False):
+    summary: Optional[str]
+    embedding: Optional[np.ndarray]
+    summary_usage: Optional[Dict[str, int]]
+    kg_usage: Optional[Dict[str, int]]
+
+
+class FinalizeAgent:
+    """Handle chapter finalization and KG updates."""
+
+    def __init__(self, kg_agent: Optional[KGMaintainerAgent] = None) -> None:
+        self.kg_agent = kg_agent or KGMaintainerAgent()
+        logger.info("FinalizeAgent initialized")
+
+    def _validate_character_updates(self, updates: Dict[str, CharacterProfile]) -> bool:
+        for name, profile in updates.items():
+            if not name or not profile.name:
+                logger.error("Invalid character update", name=name)
+                return False
+        return True
+
+    def _validate_world_updates(self, updates: Dict[str, Dict[str, WorldItem]]) -> bool:
+        for category, items in updates.items():
+            if not category:
+                logger.error("World update missing category")
+                return False
+            for item in items.values():
+                if not item.name or not item.category:
+                    logger.error(
+                        "Invalid world item", category=category, item=item.name
+                    )
+                    return False
+        return True
+
+    async def _extract_merge_and_persist(
+        self,
+        plot_outline: Dict[str, Any],
+        character_profiles: Dict[str, CharacterProfile],
+        world_building: Dict[str, Dict[str, WorldItem]],
+        chapter_number: int,
+        chapter_text: str,
+        from_flawed_draft: bool,
+    ) -> Optional[Dict[str, int]]:
+        raw_text, usage_data = await self.kg_agent._llm_extract_updates(
+            plot_outline, chapter_text, chapter_number
+        )
+        if not raw_text.strip():
+            logger.warning("LLM extraction returned no text", chapter=chapter_number)
+            return usage_data
+
+        char_updates_raw = "{}"
+        world_updates_raw = "{}"
+        triples_text = ""
+        try:
+            parsed_json = json.loads(raw_text)
+            char_updates_raw = json.dumps(parsed_json.get("character_updates", {}))
+            world_updates_raw = json.dumps(parsed_json.get("world_updates", {}))
+            triples_list = parsed_json.get("kg_triples", [])
+            if isinstance(triples_list, list):
+                triples_text = "\n".join([str(t) for t in triples_list])
+            else:
+                triples_text = str(triples_list)
+        except json.JSONDecodeError:
+            logger.warning(
+                "Failed to parse extraction JSON, attempting regex",
+                chapter=chapter_number,
+            )
+            char_match = re.search(
+                r'"character_updates"\s*:\s*({.*?})', raw_text, re.DOTALL
+            )
+            if char_match:
+                char_updates_raw = char_match.group(1)
+            world_match = re.search(
+                r'"world_updates"\s*:\s*({.*?})', raw_text, re.DOTALL
+            )
+            if world_match:
+                world_updates_raw = world_match.group(1)
+            triples_match = re.search(
+                r'"kg_triples"\s*:\s*(\[.*?\])', raw_text, re.DOTALL
+            )
+            if triples_match:
+                try:
+                    triples_list = json.loads(triples_match.group(1))
+                    if isinstance(triples_list, list):
+                        triples_text = "\n".join([str(t) for t in triples_list])
+                except json.JSONDecodeError:
+                    logger.warning(
+                        "Regex found kg_triples but JSON invalid",
+                        chapter=chapter_number,
+                    )
+
+        char_updates = self.kg_agent.parse_character_updates(
+            char_updates_raw, chapter_number
+        )
+        world_updates = self.kg_agent.parse_world_updates(
+            world_updates_raw, chapter_number
+        )
+        triples = parse_rdf_triples_with_rdflib(triples_text)
+
+        if not self._validate_character_updates(
+            char_updates
+        ) or not self._validate_world_updates(world_updates):
+            logger.error(
+                "Validation failed for extracted updates", chapter=chapter_number
+            )
+            return usage_data
+
+        self.kg_agent.merge_updates(
+            character_profiles,
+            world_building,
+            char_updates,
+            world_updates,
+            chapter_number,
+            from_flawed_draft,
+        )
+
+        if char_updates:
+            await self.kg_agent.persist_profiles(char_updates, chapter_number)
+        if world_updates:
+            await self.kg_agent.persist_world(world_updates, chapter_number)
+        if triples:
+            try:
+                await kg_queries.add_kg_triples_batch_to_db(
+                    triples, chapter_number, from_flawed_draft
+                )
+            except Exception as exc:
+                logger.error(
+                    "Failed to persist KG triples", chapter=chapter_number, exc_info=exc
+                )
+        return usage_data
+
+    async def finalize_chapter(
+        self,
+        plot_outline: Dict[str, Any],
+        character_profiles: Dict[str, CharacterProfile],
+        world_building: Dict[str, Dict[str, WorldItem]],
+        chapter_number: int,
+        final_text: str,
+        raw_llm_output: Optional[str] = None,
+        from_flawed_draft: bool = False,
+    ) -> FinalizationResult:
+        summary_task = self.kg_agent.summarize_chapter(final_text, chapter_number)
+        embedding_task = llm_service.async_get_embedding(final_text)
+        kg_task = self._extract_merge_and_persist(
+            plot_outline,
+            character_profiles,
+            world_building,
+            chapter_number,
+            final_text,
+            from_flawed_draft,
+        )
+
+        (summary_data, embedding, kg_usage) = await asyncio.gather(
+            summary_task, embedding_task, kg_task
+        )
+        summary, summary_usage = summary_data
+
+        await chapter_queries.save_chapter_data_to_db(
+            chapter_number,
+            final_text,
+            raw_llm_output or "N/A",
+            summary,
+            embedding,
+            from_flawed_draft,
+        )
+
+        return {
+            "summary": summary,
+            "embedding": embedding,
+            "summary_usage": summary_usage,
+            "kg_usage": kg_usage,
+        }

--- a/tests/test_finalize_agent.py
+++ b/tests/test_finalize_agent.py
@@ -1,0 +1,98 @@
+import asyncio
+from typing import Dict
+
+import numpy as np
+import pytest
+
+from finalize_agent import FinalizeAgent
+from kg_maintainer.models import CharacterProfile, WorldItem
+from kg_maintainer_agent import KGMaintainerAgent
+
+
+class DummyKGAgent(KGMaintainerAgent):
+    pass
+
+
+@pytest.mark.asyncio
+async def test_finalize_chapter_success(monkeypatch):
+    kg_agent = DummyKGAgent()
+    agent = FinalizeAgent(kg_agent)
+
+    async def fake_summary(text: str, num: int):
+        return "sum", {"prompt_tokens": 1}
+
+    async def fake_embedding(text: str):
+        return np.array([0.1, 0.2], dtype=np.float32)
+
+    async def fake_extract(*_args, **_kwargs):
+        return (
+            '{"character_updates": {"Alice": {"description": "Hero"}}, "world_updates": {"Places": {"Town": {"description": "Nice"}}}, "kg_triples": ["A|b|c"]}',
+            {"total_tokens": 2},
+        )
+
+    save_mock = asyncio.Future()
+    save_mock.set_result(None)
+
+    monkeypatch.setattr(kg_agent, "summarize_chapter", fake_summary)
+    monkeypatch.setattr("llm_interface.llm_service.async_get_embedding", fake_embedding)
+    monkeypatch.setattr(kg_agent, "_llm_extract_updates", fake_extract)
+    monkeypatch.setattr(kg_agent, "persist_profiles", lambda *a, **k: save_mock)
+    monkeypatch.setattr(kg_agent, "persist_world", lambda *a, **k: save_mock)
+    monkeypatch.setattr(
+        "data_access.kg_queries.add_kg_triples_batch_to_db", lambda *a, **k: save_mock
+    )
+    monkeypatch.setattr(
+        "data_access.chapter_queries.save_chapter_data_to_db", lambda *a, **k: save_mock
+    )
+
+    result = await agent.finalize_chapter({}, {}, {}, 1, "text", "raw")
+    assert result["summary"] == "sum"
+    assert np.allclose(result["embedding"], np.array([0.1, 0.2], dtype=np.float32))
+    assert result["kg_usage"] == {"total_tokens": 2}
+
+
+@pytest.mark.asyncio
+async def test_finalize_chapter_validation_failure(monkeypatch):
+    kg_agent = DummyKGAgent()
+    agent = FinalizeAgent(kg_agent)
+
+    async def fake_summary(text: str, num: int):
+        return "sum", {"prompt_tokens": 1}
+
+    async def fake_embedding(text: str):
+        return np.array([0.1, 0.2], dtype=np.float32)
+
+    async def fake_extract(*_args, **_kwargs):
+        return (
+            '{"character_updates": {"": {"description": "bad"}}, "world_updates": {}, "kg_triples": []}',
+            {"total_tokens": 2},
+        )
+
+    save_mock = asyncio.Future()
+    save_mock.set_result(None)
+
+    monkeypatch.setattr(kg_agent, "summarize_chapter", fake_summary)
+    monkeypatch.setattr("llm_interface.llm_service.async_get_embedding", fake_embedding)
+    monkeypatch.setattr(kg_agent, "_llm_extract_updates", fake_extract)
+    profiles_called: Dict[str, CharacterProfile] = {}
+    world_called: Dict[str, Dict[str, WorldItem]] = {}
+
+    async def persist_profiles(profiles, chapter):
+        profiles_called.update(profiles)
+
+    async def persist_world(world, chapter):
+        world_called.update(world)
+
+    monkeypatch.setattr(kg_agent, "persist_profiles", persist_profiles)
+    monkeypatch.setattr(kg_agent, "persist_world", persist_world)
+    monkeypatch.setattr(
+        "data_access.kg_queries.add_kg_triples_batch_to_db", lambda *a, **k: save_mock
+    )
+    monkeypatch.setattr(
+        "data_access.chapter_queries.save_chapter_data_to_db", lambda *a, **k: save_mock
+    )
+
+    result = await agent.finalize_chapter({}, {}, {}, 1, "text", None)
+    assert profiles_called == {}
+    assert world_called == {}
+    assert result["kg_usage"] == {"total_tokens": 2}


### PR DESCRIPTION
## Summary
- implement `FinalizeAgent` to own Step 6 tasks
- refactor orchestrator to call the new agent
- validate extracted updates before merging
- test new finalization workflow

## Testing
- `ruff check finalize_agent.py nana_orchestrator.py tests/test_finalize_agent.py`
- `ruff format --check finalize_agent.py nana_orchestrator.py tests/test_finalize_agent.py`
- `pytest tests/test_finalize_agent.py -v`
- `pytest tests/ -v --cov=. --cov-report=term-missing`
- `mypy .` *(fails: Module has no attribute errors)*

------
https://chatgpt.com/codex/tasks/task_e_684ddaa30c30832fa23458b6d8313298