### PR TITLE
feat(data_access): add single item query helpers

### DIFF
--- a/data_access/__init__.py
+++ b/data_access/__init__.py
@@ -12,6 +12,7 @@ from .chapter_queries import (
 )
 from .character_queries import (
     get_character_info_for_snippet_from_db,
+    get_character_profile_by_name,
     get_character_profiles_from_db,
     sync_characters,
 )
@@ -28,6 +29,7 @@ from .plot_queries import get_plot_outline_from_db, save_plot_outline_to_db
 from .world_queries import (
     get_world_building_from_db,
     get_world_elements_for_snippet_from_db,
+    get_world_item_by_id,
     sync_world_items,
 )
 from .world_queries import (
@@ -39,12 +41,14 @@ __all__ = [
     "get_plot_outline_from_db",
     "sync_characters_full_state_from_object_to_db",
     "sync_characters",
+    "get_character_profile_by_name",
     "get_character_profiles_from_db",
     "get_character_info_for_snippet_from_db",
     "sync_world_full_state_from_object_to_db",
     "sync_world_items",
     "get_world_building_from_db",
     "get_world_elements_for_snippet_from_db",
+    "get_world_item_by_id",
     "load_chapter_count_from_db",
     "save_chapter_data_to_db",
     "get_chapter_data_from_db",

--- a/data_access/character_queries.py
+++ b/data_access/character_queries.py
@@ -2,6 +2,8 @@
 import logging
 from typing import Any, Dict, List, Optional, Set, Tuple
 
+from async_lru import alru_cache  # type: ignore
+
 from neo4j.exceptions import ServiceUnavailable  # type: ignore
 
 import config
@@ -524,6 +526,91 @@ async def sync_full_state_from_object_to_db(profiles_data: Dict[str, Any]) -> bo
     except Exception as e:
         logger.error(f"Error synchronizing character profiles: {e}", exc_info=True)
         return False
+
+
+@alru_cache(maxsize=128)
+async def get_character_profile_by_name(name: str) -> Optional[CharacterProfile]:
+    """Retrieve a single ``CharacterProfile`` from Neo4j by character name."""
+    logger.info("Loading character profile '%s' from Neo4j...", name)
+
+    query = (
+        "MATCH (c:Character:Entity {name: $name})"
+        " WHERE c.is_deleted IS NULL OR c.is_deleted = FALSE"
+        " RETURN c"
+    )
+    results = await neo4j_manager.execute_read_query(query, {"name": name})
+    if not results or not results[0].get("c"):
+        logger.info("No character profile found for '%s'.", name)
+        return None
+
+    char_node = results[0]["c"]
+    profile: Dict[str, Any] = dict(char_node)
+    profile.pop("name", None)
+    profile.pop("created_ts", None)
+    profile.pop("updated_ts", None)
+
+    traits_query = (
+        "MATCH (:Character:Entity {name: $char_name})-[:HAS_TRAIT]->(t:Trait:Entity)"
+        " RETURN t.name AS trait_name"
+    )
+    trait_results = await neo4j_manager.execute_read_query(
+        traits_query, {"char_name": name}
+    )
+    profile["traits"] = sorted(
+        [tr["trait_name"] for tr in trait_results if tr and tr.get("trait_name")]
+    )
+
+    rels_query = """
+        MATCH (:Character:Entity {name: $char_name})-[r:DYNAMIC_REL]->(target:Entity)
+        WHERE r.source_profile_managed = TRUE
+        RETURN target.name AS target_name, properties(r) AS rel_props
+    """
+    rel_results = await neo4j_manager.execute_read_query(
+        rels_query, {"char_name": name}
+    )
+    relationships: Dict[str, Any] = {}
+    if rel_results:
+        for rel_rec in rel_results:
+            target_name = rel_rec.get("target_name")
+            rel_props_full = rel_rec.get("rel_props", {})
+            rel_props_cleaned = {
+                k: v
+                for k, v in rel_props_full.items()
+                if k
+                not in [
+                    "created_ts",
+                    "updated_ts",
+                    "source_profile_managed",
+                    "chapter_added",
+                ]
+            }
+            if "type" in rel_props_full:
+                rel_props_cleaned["type"] = rel_props_full["type"]
+            if "chapter_added" in rel_props_full:
+                rel_props_cleaned["chapter_added"] = rel_props_full["chapter_added"]
+            if target_name:
+                relationships[target_name] = rel_props_cleaned
+    profile["relationships"] = relationships
+
+    dev_query = (
+        "MATCH (:Character:Entity {name: $char_name})-[:DEVELOPED_IN_CHAPTER]->(dev:DevelopmentEvent:Entity)\n"
+        f"RETURN dev.summary AS summary, dev.{KG_NODE_CHAPTER_UPDATED} AS chapter, dev.{KG_IS_PROVISIONAL} AS is_provisional, dev.id as dev_id\n"
+        "ORDER BY dev.chapter_updated ASC"
+    )
+    dev_results = await neo4j_manager.execute_read_query(dev_query, {"char_name": name})
+    if dev_results:
+        for dev_rec in dev_results:
+            chapter_num = dev_rec.get("chapter")
+            summary = dev_rec.get("summary")
+            if chapter_num is not None and summary is not None:
+                dev_key = f"development_in_chapter_{chapter_num}"
+                profile[dev_key] = summary
+                if dev_rec.get(KG_IS_PROVISIONAL):
+                    profile[f"source_quality_chapter_{chapter_num}"] = (
+                        "provisional_from_unrevised_draft"
+                    )
+
+    return CharacterProfile.from_dict(name, profile)
 
 
 async def get_character_profiles_from_db() -> Dict[str, CharacterProfile]:

--- a/data_access/world_queries.py
+++ b/data_access/world_queries.py
@@ -1,7 +1,9 @@
 # data_access/world_queries.py
 import json
 import logging
-from typing import Any, Dict, List, Set, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from async_lru import alru_cache  # type: ignore
 
 import config
 import utils
@@ -576,6 +578,94 @@ async def sync_full_state_from_object_to_db(world_data: Dict[str, Any]) -> bool:
     except Exception as e:
         logger.error(f"Error synchronizing world building data: {e}", exc_info=True)
         return False
+
+
+@alru_cache(maxsize=128)
+async def get_world_item_by_id(item_id: str) -> Optional[WorldItem]:
+    """Retrieve a single ``WorldItem`` from Neo4j by its ID."""
+    logger.info("Loading world item '%s' from Neo4j...", item_id)
+
+    query = (
+        "MATCH (we:WorldElement:Entity {id: $id})"
+        " WHERE we.is_deleted IS NULL OR we.is_deleted = FALSE"
+        " RETURN we"
+    )
+    results = await neo4j_manager.execute_read_query(query, {"id": item_id})
+    if not results or not results[0].get("we"):
+        logger.info("No world item found for id '%s'.", item_id)
+        return None
+
+    we_node = results[0]["we"]
+    category = we_node.get("category")
+    item_name = we_node.get("name")
+    if not category or not item_name:
+        logger.warning("WorldElement missing category or name for id '%s'.", item_id)
+        return None
+
+    item_detail: Dict[str, Any] = dict(we_node)
+    item_detail.pop("created_ts", None)
+    item_detail.pop("updated_ts", None)
+
+    created_chapter_num = item_detail.pop(
+        KG_NODE_CREATED_CHAPTER, config.KG_PREPOPULATION_CHAPTER_NUM
+    )
+    item_detail["created_chapter"] = int(created_chapter_num)
+    item_detail[f"added_in_chapter_{created_chapter_num}"] = True
+
+    if item_detail.pop(KG_IS_PROVISIONAL, False):
+        item_detail["is_provisional"] = True
+        item_detail[f"source_quality_chapter_{created_chapter_num}"] = (
+            "provisional_from_unrevised_draft"
+        )
+    else:
+        item_detail["is_provisional"] = False
+
+    list_prop_map = {
+        "goals": "HAS_GOAL",
+        "rules": "HAS_RULE",
+        "key_elements": "HAS_KEY_ELEMENT",
+        "traits": "HAS_TRAIT_ASPECT",
+    }
+    for list_prop_key, rel_name_internal in list_prop_map.items():
+        list_values_query = f"""
+        MATCH (:WorldElement:Entity {{id: $we_id_param}})-[:{rel_name_internal}]->(v:ValueNode:Entity {{type: $value_node_type_param}})
+        RETURN v.value AS item_value
+        ORDER BY v.value ASC
+        """
+        list_val_res = await neo4j_manager.execute_read_query(
+            list_values_query,
+            {"we_id_param": item_id, "value_node_type_param": list_prop_key},
+        )
+        item_detail[list_prop_key] = sorted(
+            [
+                res_item["item_value"]
+                for res_item in list_val_res
+                if res_item and res_item.get("item_value") is not None
+            ]
+        )
+
+    elab_query = f"""
+    MATCH (:WorldElement:Entity {{id: $we_id_param}})-[:ELABORATED_IN_CHAPTER]->(elab:WorldElaborationEvent:Entity)
+    RETURN elab.summary AS summary, elab.{KG_NODE_CHAPTER_UPDATED} AS chapter, elab.{KG_IS_PROVISIONAL} AS is_provisional
+    ORDER BY elab.chapter_updated ASC
+    """
+    elab_results = await neo4j_manager.execute_read_query(
+        elab_query, {"we_id_param": item_id}
+    )
+    if elab_results:
+        for elab_rec in elab_results:
+            chapter_val = elab_rec.get("chapter")
+            summary_val = elab_rec.get("summary")
+            if chapter_val is not None and summary_val is not None:
+                elab_key = f"elaboration_in_chapter_{chapter_val}"
+                item_detail[elab_key] = summary_val
+                if elab_rec.get(KG_IS_PROVISIONAL):
+                    item_detail[f"source_quality_chapter_{chapter_val}"] = (
+                        "provisional_from_unrevised_draft"
+                    )
+
+    item_detail["id"] = item_id
+    return WorldItem.from_dict(category, item_name, item_detail)
 
 
 async def get_world_building_from_db() -> Dict[str, Dict[str, WorldItem]]:

--- a/tests/test_data_access_single_fetch.py
+++ b/tests/test_data_access_single_fetch.py
@@ -1,0 +1,92 @@
+import pytest
+from unittest.mock import AsyncMock
+
+from data_access import character_queries, world_queries
+from kg_constants import KG_NODE_CREATED_CHAPTER
+
+
+@pytest.mark.asyncio
+async def test_get_character_profile_by_name(monkeypatch):
+    async def fake_read(query, params=None):
+        if "RETURN c" in query:
+            return [
+                {
+                    "c": {
+                        "name": "Alice",
+                        "description": "hero",
+                        "status": "active",
+                        "created_ts": 1,
+                    }
+                }
+            ]
+        if "HAS_TRAIT" in query:
+            return [{"trait_name": "brave"}]
+        if "DYNAMIC_REL" in query:
+            return [{"target_name": "Bob", "rel_props": {"type": "KNOWS"}}]
+        if "DEVELOPED_IN_CHAPTER" in query:
+            return [
+                {
+                    "summary": "growth",
+                    "chapter": 1,
+                    "is_provisional": False,
+                    "dev_id": "d1",
+                }
+            ]
+        return []
+
+    monkeypatch.setattr(
+        character_queries.neo4j_manager,
+        "execute_read_query",
+        AsyncMock(side_effect=fake_read),
+    )
+
+    profile = await character_queries.get_character_profile_by_name("Alice")
+    assert profile
+    assert profile.name == "Alice"
+    assert profile.traits == ["brave"]
+    assert profile.relationships["Bob"]["type"] == "KNOWS"
+    assert profile.updates["development_in_chapter_1"] == "growth"
+
+    character_queries.get_character_profile_by_name.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_get_world_item_by_id(monkeypatch):
+    async def fake_read(query, params=None):
+        if "RETURN we" in query:
+            return [
+                {
+                    "we": {
+                        "id": "places_city",
+                        "name": "City",
+                        "category": "places",
+                        KG_NODE_CREATED_CHAPTER: 1,
+                    }
+                }
+            ]
+        if "HAS_GOAL" in query:
+            return [{"item_value": "Thrive"}]
+        if (
+            "HAS_RULE" in query
+            or "HAS_KEY_ELEMENT" in query
+            or "HAS_TRAIT_ASPECT" in query
+        ):
+            return []
+        if "ELABORATED_IN_CHAPTER" in query:
+            return [{"summary": "history", "chapter": 2, "is_provisional": False}]
+        return []
+
+    monkeypatch.setattr(
+        world_queries.neo4j_manager,
+        "execute_read_query",
+        AsyncMock(side_effect=fake_read),
+    )
+
+    item = await world_queries.get_world_item_by_id("places_city")
+    assert item
+    assert item.name == "City"
+    assert item.category == "places"
+    assert item.properties["goals"] == ["Thrive"]
+    assert item.properties["elaboration_in_chapter_2"] == "history"
+
+    world_queries.get_world_item_by_id.cache_clear()


### PR DESCRIPTION
## Summary
- add `get_character_profile_by_name` to fetch a single character record
- add `get_world_item_by_id` for retrieving individual world elements
- expose the new helpers from `data_access/__init__`
- cover new helpers with unit tests

## Testing
- `ruff check . && ruff format --check .`
- `pytest tests/ -v --cov=. --cov-report=term-missing` *(fails: ModuleNotFoundError)*
- `mypy .` *(fails: several errors)*

------
https://chatgpt.com/codex/tasks/task_e_684e457b42ac832fb40458c6fd352cfa