### PR TITLE
Enhance chapter planning with KG context

### DIFF
--- a/planner_agent.py
+++ b/planner_agent.py
@@ -6,14 +6,15 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import config
 from data_access import chapter_queries
+from kg_maintainer.models import CharacterProfile, SceneDetail, WorldItem
 from llm_interface import llm_service
-from prompt_renderer import render_prompt
 from prompt_data_getters import (
     get_character_state_snippet_for_prompt,
+    get_planning_context_from_kg,
     get_reliable_kg_facts_for_drafting_prompt,
     get_world_state_snippet_for_prompt,
 )
-from kg_maintainer.models import CharacterProfile, SceneDetail, WorldItem
+from prompt_renderer import render_prompt
 
 logger = logging.getLogger(__name__)
 
@@ -138,7 +139,6 @@ class PlannerAgent:
                         # For optional fields, this will be None.
                         processed_scene_dict[key_internal_name] = None
 
-
             scenes_data.append(processed_scene_dict)  # type: ignore
 
         if not scenes_data:
@@ -220,6 +220,10 @@ class PlannerAgent:
         )
         world_state_snippet_plain_text = await get_world_state_snippet_for_prompt(
             world_building, chapter_number
+        )
+
+        planning_kg_context = await get_planning_context_from_kg(
+            plot_outline, chapter_number
         )
 
         future_plot_context_parts: List[str] = []
@@ -309,6 +313,7 @@ class PlannerAgent:
                 "plot_point_focus": plot_point_focus,
                 "future_plot_context_str": future_plot_context_str,
                 "context_summary_str": context_summary_str,
+                "planning_kg_context": planning_kg_context,
                 "kg_context_section": kg_context_section,
                 "character_state_snippet_plain_text": character_state_snippet_plain_text,
                 "world_state_snippet_plain_text": world_state_snippet_plain_text,

--- a/prompts/planner_agent/scene_plan.j2
+++ b/prompts/planner_agent/scene_plan.j2
@@ -33,6 +33,9 @@ You are an expert novelist and storyteller, acting as a "showrunner" to plan out
 **Previous Chapter Summary/Ending:**
 {{ context_summary_str if context_summary_str else "This is the first chapter." }}
 
+**Knowledge Graph Planning Context:**
+{{ planning_kg_context }}
+
 **Knowledge Graph Context (Characters & World):**
 {{ kg_context_section }}
 {{ character_state_snippet_plain_text }}

--- a/tests/test_planning_context.py
+++ b/tests/test_planning_context.py
@@ -1,0 +1,42 @@
+import pytest
+
+from prompt_data_getters import get_planning_context_from_kg
+
+
+@pytest.mark.asyncio
+async def test_get_planning_context_from_kg(monkeypatch):
+    async def fake_get_novel_info_property_from_db(key):
+        return {"theme": "courage", "central_conflict": "war"}.get(key)
+
+    async def fake_get_most_recent_value_from_db(
+        subject, predicate, chapter_limit=None, include_provisional=False
+    ):
+        if subject == "Alice" and predicate == "status_is":
+            return "Alive"
+        if subject == "Alice" and predicate == "located_in":
+            return "Town"
+        return None
+
+    async def fake_query_kg_from_db(*args, **kwargs):
+        return [{"predicate": "ALLY_OF", "object": "Bob"}]
+
+    monkeypatch.setattr(
+        "data_access.kg_queries.get_novel_info_property_from_db",
+        fake_get_novel_info_property_from_db,
+    )
+    monkeypatch.setattr(
+        "data_access.kg_queries.get_most_recent_value_from_db",
+        fake_get_most_recent_value_from_db,
+    )
+    monkeypatch.setattr(
+        "data_access.kg_queries.query_kg_from_db",
+        fake_query_kg_from_db,
+    )
+
+    result = await get_planning_context_from_kg(
+        {"protagonist_name": "Alice"}, 3, max_facts_per_char=3
+    )
+
+    assert "Novel theme: courage" in result
+    assert "Alice's status is: Alive" in result
+    assert "relationship (ALLY OF)" in result


### PR DESCRIPTION
## Summary
- add `get_planning_context_from_kg` for richer plan info
- integrate planning KG data into `PlannerAgent`
- extend planning prompt template to include KG context
- cover new behaviour with a unit test

## Testing
- `ruff check .`
- `ruff format --check .`
- `pytest tests/ -v --cov=. --cov-report=term-missing`
- `mypy .` *(fails: many missing stubs and config attributes)*

------
https://chatgpt.com/codex/tasks/task_e_684f09a382b8832fa168461a149af5a2