### PR TITLE
Improve knowledge graph entity lookup

### DIFF
--- a/data_access/__init__.py
+++ b/data_access/__init__.py
@@ -13,6 +13,7 @@ from .chapter_queries import (
 from .character_queries import (
     get_character_info_for_snippet_from_db,
     get_character_profile_by_name,
+    resolve_character_name,
     get_character_profiles_from_db,
     sync_characters,
 )
@@ -44,6 +45,7 @@ __all__ = [
     "sync_characters_full_state_from_object_to_db",
     "sync_characters",
     "get_character_profile_by_name",
+    "resolve_character_name",
     "get_character_profiles_from_db",
     "get_character_info_for_snippet_from_db",
     "sync_world_full_state_from_object_to_db",


### PR DESCRIPTION
## Summary
- expand data access layer with canonical character name resolution
- export new helper in `data_access.__init__`
- add fallback logic when fetching world items by id
- cover new behaviour with tests

## Testing
- `ruff check .`
- `ruff format --check .`
- `pytest tests/ -v --cov=. --cov-report=term-missing`
- `mypy .` *(fails: Module has no attribute errors)*

------
https://chatgpt.com/codex/tasks/task_e_684f1975d824832f82e6b4ec1806ae50