### PR TITLE
Integrate neomodel models for CRUD operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ It's highly recommended to use a Python virtual environment:
 python -m venv venv
 source venv/bin/activate  # On Windows: venv\Scripts\activate
 pip install -r requirements.txt
+# neomodel is included for higher-level graph models
 python -m spacy download en_core_web_sm
 ```
 
@@ -134,6 +135,7 @@ NEO4J_URI="bolt://localhost:7687"
 NEO4J_USER="neo4j"
 NEO4J_PASSWORD="saga_password"
 NEO4J_DATABASE="neo4j" # Or your specific database name if not default
+# neomodel is automatically configured with these settings
 
 # Model Aliases (Set to the names of models available on your OPENAI_API_BASE server)
 LARGE_MODEL="Qwen3-14B-Q4"    # Or your preferred large model

--- a/core_db/base_db_manager.py
+++ b/core_db/base_db_manager.py
@@ -68,6 +68,21 @@ class Neo4jManagerSingleton:
             )
             await self.driver.verify_connectivity()
             self.logger.info(f"Successfully connected to Neo4j at {config.NEO4J_URI}")
+
+            # Configure neomodel to use the same connection
+            try:
+                from neomodel import config as nm_config
+
+                nm_config.DATABASE_URL = (
+                    f"bolt://{config.NEO4J_USER}:{config.NEO4J_PASSWORD}@"
+                    f"{config.NEO4J_URI.split('//')[-1]}"
+                )
+                if config.NEO4J_DATABASE:
+                    nm_config.DATABASE_NAME = config.NEO4J_DATABASE
+            except Exception as nm_exc:  # pragma: no cover - log but don't fail
+                self.logger.warning(
+                    "Failed to configure neomodel: %s", nm_exc, exc_info=True
+                )
         except ServiceUnavailable as e:
             self.logger.critical(
                 f"Neo4j connection failed: {e}. Ensure the Neo4j database is running and accessible."

--- a/data_access/models/__init__.py
+++ b/data_access/models/__init__.py
@@ -1,0 +1,36 @@
+"""Neomodel node definitions for Saga."""
+
+from __future__ import annotations
+
+from neomodel import (
+    AsyncStructuredNode,
+    RelationshipTo,
+    StringProperty,
+    UniqueIdProperty,
+)
+
+
+class TraitNode(AsyncStructuredNode):
+    """Represents a trait that a character may have."""
+
+    name = StringProperty(unique_index=True, required=True)
+
+
+class CharacterNode(AsyncStructuredNode):
+    """Represents a character in the novel."""
+
+    uid = UniqueIdProperty()
+    name = StringProperty(unique_index=True, required=True)
+    description = StringProperty()
+    status = StringProperty()
+
+    traits = RelationshipTo("TraitNode", "HAS_TRAIT")
+
+
+class WorldElementNode(AsyncStructuredNode):
+    """Represents a world element such as a location or item."""
+
+    uid = UniqueIdProperty()
+    identifier = StringProperty(unique_index=True, required=True)
+    name = StringProperty()
+    category = StringProperty()

--- a/data_access/models/__init__.py
+++ b/data_access/models/__init__.py
@@ -34,3 +34,6 @@ class WorldElementNode(AsyncStructuredNode):
     identifier = StringProperty(unique_index=True, required=True)
     name = StringProperty()
     category = StringProperty()
+
+
+__all__ = ["TraitNode", "CharacterNode", "WorldElementNode"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 async_lru==2.0.5
 httpx>=0.27.0,<0.28.0 # Updated to resolve ollama/openai conflict
 neo4j==5.28.1
+neomodel>=5.5,<6
 numpy==2.2.6
 openai==1.30.1
 ollama==0.2.0

--- a/tests/test_neomodel_integration.py
+++ b/tests/test_neomodel_integration.py
@@ -1,0 +1,30 @@
+import pytest
+from unittest.mock import AsyncMock
+
+from data_access.character_queries import _save_character_ogm
+from data_access.models import CharacterNode, TraitNode
+from kg_maintainer.models import CharacterProfile
+
+
+@pytest.mark.asyncio
+async def test_save_character_ogm(monkeypatch):
+    mock_char = AsyncMock()
+    mock_char.traits.connect = AsyncMock()
+    nodes_mgr = AsyncMock()
+    nodes_mgr.get_or_none = AsyncMock(return_value=None)
+    monkeypatch.setattr(CharacterNode, "nodes", nodes_mgr)
+    monkeypatch.setattr(CharacterNode, "save", AsyncMock(return_value=mock_char))
+
+    trait_mgr = AsyncMock()
+    trait_mgr.get_or_none = AsyncMock(return_value=None)
+    trait_instance = AsyncMock()
+    monkeypatch.setattr(TraitNode, "nodes", trait_mgr)
+    monkeypatch.setattr(TraitNode, "save", AsyncMock(return_value=trait_instance))
+
+    profile = CharacterProfile(name="Alice", description="desc", traits=["brave"])
+    await _save_character_ogm(profile)
+
+    nodes_mgr.get_or_none.assert_awaited_with(name="Alice")
+    assert CharacterNode.save.await_count
+    trait_mgr.get_or_none.assert_awaited()
+    mock_char.traits.connect.assert_awaited()


### PR DESCRIPTION
## Summary
- add `neomodel` dependency
- configure `neomodel` on DB connect
- define `CharacterNode`, `TraitNode`, and `WorldElementNode`
- persist characters and world elements via neomodel in CRUD helpers
- document neomodel usage in README
- add test for neomodel integration

## Testing
- `ruff check . && ruff format --check .`
- `pytest tests/ -v --cov=. --cov-report=term-missing`
- `mypy .` *(fails: "Skipping analyzing 'neomodel': module is installed, but missing library stubs or py.typed marker" et al.)*

------
https://chatgpt.com/codex/tasks/task_e_684f60d29e30832f9da800dbeafad0ed