### PR TITLE
feat(prompts): clarify sample usage

### DIFF
--- a/agents/comprehensive_evaluator_agent.py
+++ b/agents/comprehensive_evaluator_agent.py
@@ -225,6 +225,7 @@ class ComprehensiveEvaluatorAgent:
     "suggested_fix_focus": "Expand on John's internal thoughts and feelings upon discovering the Baron's betrayal. Show, don't just tell, the emotional weight of this moment. Describe the fight with more detail and tension."
   }
 ]
+**Ignore the narrative details in this example. It shows the required format only.**
 """
         # Note: The user/developer needs to update the actual LLM prompt to request JSON.
         # This tool only changes the agent's parsing logic and the example string.

--- a/agents/planner_agent.py
+++ b/agents/planner_agent.py
@@ -290,6 +290,7 @@ class PlannerAgent:
     "relationship_development": "An antagonistic relationship with Thane and the Crimson Hand is established."
   }
 ]
+**Ignore the narrative details in this example. It shows the required format only.**
 """
         prompt = render_prompt(
             "planner_agent/scene_plan.j2",

--- a/agents/world_continuity_agent.py
+++ b/agents/world_continuity_agent.py
@@ -146,6 +146,7 @@ class WorldContinuityAgent:
     " (e.g., memory loss, testing her)."
   }
 ]
+**Ignore the narrative details in this example. It shows the required format only.**
 """
         prompt = render_prompt(
             "world_continuity_agent/consistency_check.j2",

--- a/processing/revision_logic.py
+++ b/processing/revision_logic.py
@@ -279,6 +279,7 @@ IF THE PROBLEM WAS:
 THEN YOUR 'replace_with' TEXT MIGHT BE (just the text, no other explanation):
 A chill traced Elara's spine, not from the crypt's cold, but from the translucent figure coalescing before her. Her breath hitched, a silent scream trapped in her throat as the ghostly visage turned its empty sockets towards her. Every instinct screamed to flee, but her feet felt rooted to the stone floor, a terrifying paralysis gripping her.
 --- End of Example ---
+**Ignore the narrative details in this example. It shows the required format only.**
 """
 
     prompt_lines = []

--- a/prompts/bootstrapper/fill_character_field.j2
+++ b/prompts/bootstrapper/fill_character_field.j2
@@ -29,5 +29,6 @@ Your task is to generate a single, compelling value for a specific field in a ch
   "description": "Jules Vidant is a sharp-tongued private eye who navigates the city's dual nature with a weary cynicism. His wit is his shield, hiding a deep-seated desire to protect the innocent caught between the mundane world of day and the magical chaos of night."
 }
 ```
+**Ignore the narrative details in this example. It shows the required format only.**
 
 Now, generate the JSON for the `{{ field_name }}` field.

--- a/prompts/bootstrapper/fill_plot_field.j2
+++ b/prompts/bootstrapper/fill_plot_field.j2
@@ -24,5 +24,6 @@ Your task is to generate a single, compelling value for a specific field in the 
   "logline": "In a city that's magically transformed by night, a cynical private investigator must unravel a conspiracy that threatens to merge the mundane and the monstrous forever."
 }
 ```
+**Ignore the narrative details in this example. It shows the required format only.**
 
 Now, generate the JSON for the `{{ field_name }}` field based on the provided context.

--- a/prompts/bootstrapper/fill_plot_points.j2
+++ b/prompts/bootstrapper/fill_plot_points.j2
@@ -29,5 +29,6 @@ Your task is to generate a list of key plot points to complete a novel's narrati
   ]
 }
 ```
+**Ignore the narrative details in this example. It shows the required format only.**
 
 Now, generate the JSON for the `plot_points` field with `{{ list_count }}` items.

--- a/prompts/bootstrapper/fill_world_item_field.j2
+++ b/prompts/bootstrapper/fill_world_item_field.j2
@@ -29,5 +29,6 @@ Your task is to generate a single, compelling value for a specific field in a wo
   "atmosphere": "An electric tension hangs in the air, thick with the scent of ozone and forgotten magic. Shadows seem to stretch and twist in the periphery, and a low, constant hum resonates from the cobblestones, a sound felt more than heard."
 }
 ```
+**Ignore the narrative details in this example. It shows the required format only.**
 
 Now, generate the JSON for the `{{ field_name }}` field.

--- a/prompts/comprehensive_evaluator_agent/evaluate_chapter.j2
+++ b/prompts/comprehensive_evaluator_agent/evaluate_chapter.j2
@@ -48,5 +48,6 @@ If information is incomplete for any category, explain the limitation within you
 ```json
 {{ few_shot_eval_example_str.strip() }}
 ```
+**Ignore the narrative details in this example. It shows the required format only.**
 
 Begin your JSON output now:

--- a/prompts/kg_maintainer_agent/enrich_character.j2
+++ b/prompts/kg_maintainer_agent/enrich_character.j2
@@ -29,3 +29,4 @@ No specific chapter context was found for this character. Base your description 
 {
   "description": "The enigmatic and stoic keeper of the Sunken Library, Master Kael is an ancient being who tests those seeking the library's secrets."
 }
+**Ignore the narrative details in this example. It shows the required format only.**

--- a/prompts/kg_maintainer_agent/enrich_world_element.j2
+++ b/prompts/kg_maintainer_agent/enrich_world_element.j2
@@ -31,3 +31,4 @@ No specific chapter context was found for this element. Base your description on
 {
   "description": "A mysterious, floating artifact that hums with a low energy, sought by the protagonist for its map-like properties. It is said to have fallen from the stars."
 }
+**Ignore the narrative details in this example. It shows the required format only.**

--- a/prompts/kg_maintainer_agent/extract_updates.j2
+++ b/prompts/kg_maintainer_agent/extract_updates.j2
@@ -73,3 +73,4 @@ You are an expert knowledge graph extractor for a creative writing project. Your
     "Location:Sunken Library | HAS_RULE | Knowledge is only given to the worthy"
   ]
 }
+**Ignore the narrative details in this example. It shows the required format only.**

--- a/prompts/planner_agent/scene_plan.j2
+++ b/prompts/planner_agent/scene_plan.j2
@@ -43,5 +43,6 @@ You are an expert novelist and storyteller, acting as a "showrunner" to plan out
 ```json
 {{ few_shot_scene_plan_example_str }}
 ```
+**Ignore the narrative details in this example. It shows the required format only.**
 
 Now, generate the complete JSON array for the scene plan of Chapter {{ chapter_number }}.

--- a/prompts/world_continuity_agent/consistency_check.j2
+++ b/prompts/world_continuity_agent/consistency_check.j2
@@ -47,5 +47,6 @@ If any part of the reference material is unclear or incomplete, note the uncerta
 ```json
 {{ few_shot_consistency_example_str.strip() }}
 ```
+**Ignore the narrative details in this example. It shows the required format only.**
 
 Begin your JSON output now:


### PR DESCRIPTION
## Summary
- add clarifying instruction after few-shot examples in prompt templates
- append format note to embedded Python examples

## Testing
- `ruff check . && ruff format --check .`
- `pytest tests/ -v --cov=. --cov-report=term-missing`
- `mypy .` *(fails: Library stubs not installed for `yaml`, plus 338 other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6851d8bc8c9c832f8b4641b0c3cb61e1