### PR TITLE
feat(agents): support nested user story yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ The first time SAGA runs (`python main.py`), it will automatically attempt to cr
 ### 5. (Optional) Provide Initial Story Elements
 
 To guide SAGA with your own story ideas, create a `user_story_elements.yaml` file in the project's root directory.
-You can use `user_story_elements.yaml.example` as a template.
+You can use `user_story_elements.yaml.example` as a template. The YAML can be simple or include nested fields like the `characters` section with supporting characters.
 Use the `[Fill-in]` placeholder for any elements you want SAGA to generate. If this file is not present or empty, SAGA will generate these elements based on its configuration.
 
 ### 6. (Optional) Configure "Unhinged Mode" Data

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -8,6 +8,7 @@ from .agent_models import (
 )
 from .kg_models import CharacterProfile, WorldItem
 from .user_input_models import (
+    CharacterGroupModel,
     KeyLocationModel,
     NovelConceptModel,
     PlotElementsModel,
@@ -31,6 +32,7 @@ __all__ = [
     "KeyLocationModel",
     "SettingModel",
     "PlotElementsModel",
+    "CharacterGroupModel",
     "UserStoryInputModel",
     "user_story_to_objects",
 ]

--- a/tests/test_user_story_models.py
+++ b/tests/test_user_story_models.py
@@ -5,6 +5,7 @@ from initialization.data_loader import (
     load_user_supplied_model as _load_user_supplied_data,
 )
 from models.user_input_models import (
+    CharacterGroupModel,
     NovelConceptModel,
     ProtagonistModel,
     UserStoryInputModel,
@@ -41,4 +42,19 @@ def test_user_story_to_objects():
     plot, characters, world_items = user_story_to_objects(model)
     assert plot["title"] == "My Tale"
     assert "Hero" in characters
+    assert world_items == []
+
+
+def test_user_story_to_objects_nested_characters():
+    model = UserStoryInputModel(
+        characters=CharacterGroupModel(
+            protagonist=ProtagonistModel(name="Saga"),
+            antagonist=ProtagonistModel(name="Collective"),
+            supporting_characters=[ProtagonistModel(name="Dr. Larkin", role="mentor")],
+        ),
+    )
+    plot, characters, world_items = user_story_to_objects(model)
+    assert plot.get("protagonist_name") == "Saga"
+    assert "Saga" in characters
+    assert characters["Dr. Larkin"].updates["role"] == "mentor"
     assert world_items == []

--- a/user_story_elements.yaml.example
+++ b/user_story_elements.yaml.example
@@ -1,32 +1,32 @@
 # SAGA Story Elements File (YAML Example)
-# This file outlines the core elements of the story.
+# Illustrates both basic and detailed fields.
 
 novel_concept:
-  title: "[Fill-in]" # Quotes optional for simple strings, good for strings with special chars
+  title: "[Fill-in]"
   genre: "hard sci-fi"
   setting: "a frontier town on the edge of unexplored alien wilderness"
   logline: "[Fill-in]"
   theme: "the limits of human knowledge"
 
-protagonist:
-  name: "Jules Vidant"
-  description: "[Fill-in]"
-  traits:
-    - "clever"
-    - "resourceful"
-    - "inventive"
-    - "witty"
-  motivation: "[Fill-in]"
-
-antagonist:
-  name: "Tula Veridian"
-  description: "[Fill-in]"
-  traits:
-    - "resourceful"
-    - "intimidating"
-    - "intelligent"
-    - "crafty"
-  motivation: "[Fill-in]"
+characters:
+  protagonist:
+    name: "Jules Vidant"
+    description: "[Fill-in]"
+    traits:
+      - "clever"
+      - "resourceful"
+    motivation: "[Fill-in]"
+  antagonist:
+    name: "Tula Veridian"
+    description: "[Fill-in]"
+    traits:
+      - "intimidating"
+      - "crafty"
+    motivation: "[Fill-in]"
+  supporting_characters:
+    - name: "Dr. Larkin"
+      description: "[Fill-in]"
+      role: "mentor"
 
 setting:
   primary_setting_overview: "a frontier town on the edge of unexplored alien wilderness"
@@ -34,35 +34,19 @@ setting:
     - name: "[Fill-in]"
       description: "[Fill-in]"
       atmosphere: "[Fill-in]"
-    - name: "[Fill-in]"
-      description: "[Fill-in]"
-      atmosphere: "[Fill-in]"
-    - name: "[Fill-in]"
-      description: "[Fill-in]"
-      atmosphere: "[Fill-in]"
 
 plot_elements:
   inciting_incident: "[Fill-in]"
-  plot_points: # List of major turning points or events
-    - "[Fill-in]"
-    - "[Fill-in]"
-    - "[Fill-in]"
+  plot_points:
     - "[Fill-in]"
   central_conflict: "[Fill-in]"
   stakes: "[Fill-in]"
 
 style_and_tone:
-  narrative_style: "First-person (Jules's perspective) OR Third-person limited"
+  narrative_style: "First-person (Jules's perspective)"
   tone: "[Fill-in]"
-  pacing: "Generally fast-paced during action, slower during investigative and reflective moments."
+  pacing: "Generally fast-paced during action"
 
-# Optional: For more complex world-building elements if not covered by KG
-# world_specifics:
-#   magic_system_or_technology:
-#     name: "Temporal Displacement Units (TDUs)"
-#     rules:
-#       - "Require significant energy, prone to temporal drift if not calibrated."
-#       - "Extended use can cause 'chronal sickness'."
-#     limitations:
-#       - "Cannot easily change 'fixed points' in time."
-#       - "Travel to 'erased' timelines is extremely hazardous."
+symbolism:
+  - symbol: "The Golden Record"
+    meaning: "[Fill-in]"


### PR DESCRIPTION
## Summary
- allow nested `characters` and `symbolism` sections in `user_story_elements.yaml`
- export `CharacterGroupModel` for external use
- extend tests to cover nested character parsing
- update example YAML and README notice

## Testing
- `ruff check . && ruff format --check .`
- `pytest tests/ -v --cov=. --cov-report=term-missing` *(fails: unrecognized arguments)*
- `mypy .` *(fails: multiple missing stubs)*


------
https://chatgpt.com/codex/tasks/task_e_68546e7dd204832fb10ecc415241dcbe