### PR TITLE
feat(kg): heal dynamic relationships

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ SAGA constructs a dynamic, interconnected understanding of the story's world, ch
     *   Leverages text embeddings (via Ollama) and Neo4j vector similarity search to construct semantically relevant context from previous chapters, ensuring narrative flow and tone.
     *   Integrates key factual data extracted from the Knowledge Graph to ground the LLM in established canon.
 *   **Iterative Drafting, Evaluation, & Revision Cycle:** Chapters undergo a rigorous process of drafting, multi-faceted evaluation, and intelligent revision (patch-based or full rewrite) to enhance quality and coherence.
-*   **Dynamic Knowledge Graph Updates & Healing:** The system "learns" from generated content. The `KGMaintainerAgent` extracts new information (character updates, world-building changes, KG triples) from final chapter text and performs periodic maintenance to resolve duplicate entities and enrich "thin" nodes.
+*   **Dynamic Knowledge Graph Updates & Healing:** The system "learns" from generated content. The `KGMaintainerAgent` extracts new information (character updates, world-building changes, KG triples) from final chapter text and performs periodic maintenance to resolve duplicate entities, promote dynamic relationships, deduplicate them, and enrich "thin" nodes.
 *   **Provisional Data Handling:** Explicitly tracks and manages the provisional status of data derived from unrevised or flawed drafts, ensuring a distinction between canonical and tentative information in the knowledge graph.
 *   **Flexible Configuration (`config.py` & `.env`):**
     *   Extensive options for LLM endpoints, model selection per task, API keys, Neo4j connection details, generation parameters, and more, managed by Pydantic.

--- a/agents/kg_maintainer_agent.py
+++ b/agents/kg_maintainer_agent.py
@@ -444,6 +444,14 @@ class KGMaintainerAgent:
         # 3. Entity Resolution
         await self._run_entity_resolution()
 
+        # 4. Relationship Healing
+        promoted = await kg_queries.promote_dynamic_relationships()
+        if promoted:
+            logger.info("KG Healer: Promoted %d dynamic relationships.", promoted)
+        removed = await kg_queries.deduplicate_relationships()
+        if removed:
+            logger.info("KG Healer: Deduplicated %d relationships.", removed)
+
         logger.info("KG Healer/Enricher: Maintenance cycle complete.")
 
     async def _find_and_enrich_thin_nodes(self) -> List[Tuple[str, Dict[str, Any]]]:

--- a/tests/test_kg_heal.py
+++ b/tests/test_kg_heal.py
@@ -30,3 +30,42 @@ async def test_normalize_existing_relationship_types(monkeypatch):
     normalized = {params["new"] for _, params in executed}
     assert "KNOWS" in normalized
     assert "IS_FRIEND_OF" in normalized
+
+
+@pytest.mark.asyncio
+async def test_promote_dynamic_relationships(monkeypatch):
+    async def fake_types():
+        return ["KNOWS", "ALLY_OF"]
+
+    async def fake_write(query, params=None):
+        assert params == {"valid_types": ["KNOWS", "ALLY_OF"]}
+        return [{"promoted": 2}]
+
+    monkeypatch.setattr(
+        kg_queries,
+        "get_defined_relationship_types",
+        AsyncMock(side_effect=fake_types),
+    )
+    monkeypatch.setattr(
+        kg_queries.neo4j_manager,
+        "execute_write_query",
+        AsyncMock(side_effect=fake_write),
+    )
+
+    promoted = await kg_queries.promote_dynamic_relationships()
+    assert promoted == 2
+
+
+@pytest.mark.asyncio
+async def test_deduplicate_relationships(monkeypatch):
+    async def fake_write(query, params=None):
+        return [{"removed": 1}]
+
+    monkeypatch.setattr(
+        kg_queries.neo4j_manager,
+        "execute_write_query",
+        AsyncMock(side_effect=fake_write),
+    )
+
+    removed = await kg_queries.deduplicate_relationships()
+    assert removed == 1


### PR DESCRIPTION
## Summary
- promote dynamic relationships to defined types
- deduplicate identical relationships
- run new healing steps in `KGMaintainerAgent`
- document healing improvements
- test relationship healing functions

## Testing
- `ruff check .`
- `ruff format --check .`
- `pytest tests/ -v --cov=. --cov-report=term-missing`
- `mypy .` *(fails: Module has no attribute errors)*

------
https://chatgpt.com/codex/tasks/task_e_6854db677c5c832fbb68a553659ee4f0