### PR TITLE
feat(orchestrator): dynamic chapter loop

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,7 +48,7 @@ UNHINGED_PLOT_MODE=False
 # Number of total plot points in the whole narrative
 TARGET_PLOT_POINTS_INITIAL_GENERATION=18
 
-# Number of chapters to generate per run
+# Maximum chapters to generate per run; loop stops early if no plot points remain
 CHAPTERS_PER_RUN=6
 
 # Scene Planning (Agentic Planning)

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ SAGA's NANA engine orchestrates a sophisticated pipeline for novel generation:
         *   Otherwise, or if key elements are marked `[Fill-in]`, the `bootstrapper` modules fill in the plot outline, character profiles, and world-building details via targeted LLM calls.
     *   **KG Pre-population:** The `KGMaintainerAgent` performs a full sync of this foundational story data to the Neo4j graph.
 
-2.  **Chapter Generation Loop (Iterates for `CHAPTERS_PER_RUN`):**
+2.  **Chapter Generation Loop (up to `CHAPTERS_PER_RUN` chapters):**
     *   **(A) Prerequisites (`orchestration.chapter_flow`):**
         *   Retrieves the current **Plot Point Focus** for the chapter.
         *   **Planning (if enabled):** The `PlannerAgent` creates a detailed scene-by-scene plan.
@@ -194,7 +194,7 @@ python main.py
 
 *   **First Run:** SAGA will perform initial setup (plot, world, characters based on `user_story_elements.yaml` or generation) and pre-populate the Neo4j knowledge graph.
 *   **Subsequent Runs:** It will load the existing state from Neo4j and continue generating chapters from where it left off.
-*   The number of chapters generated per run is controlled by `CHAPTERS_PER_RUN` in `config.py`.
+*   The orchestrator recalculates pending plot points before each chapter and continues until none remain or `CHAPTERS_PER_RUN` chapters have been written.
 
 Output files (chapters, logs, debug information) will be saved in the directory specified by `BASE_OUTPUT_DIR` (default: `novel_output`). This directory is ignored by Git to keep generated data out of version control.
 

--- a/tests/test_novel_generation_dynamic.py
+++ b/tests/test_novel_generation_dynamic.py
@@ -1,0 +1,51 @@
+import pytest
+from unittest.mock import AsyncMock
+
+import config
+import utils
+from orchestration.nana_orchestrator import NANA_Orchestrator
+from data_access import chapter_queries
+from core.db_manager import neo4j_manager
+
+
+@pytest.mark.asyncio
+async def test_dynamic_chapter_adjustment(monkeypatch):
+    monkeypatch.setattr(utils, "load_spacy_model_if_needed", lambda: None)
+    monkeypatch.setattr(config, "CHAPTERS_PER_RUN", 3)
+
+    orch = NANA_Orchestrator()
+    monkeypatch.setattr(orch, "_update_rich_display", lambda *a, **k: None)
+
+    orch.plot_outline = {"title": "T", "plot_points": ["p1", "p2"]}
+    orch.chapter_count = 0
+
+    calls = []
+
+    async def fake_run(ch):
+        calls.append(ch)
+        if ch == 1:
+            orch.plot_outline["plot_points"].append("p3")
+        orch.chapter_count = ch
+        return "text"
+
+    monkeypatch.setattr(
+        orch, "run_chapter_generation_process", AsyncMock(side_effect=fake_run)
+    )
+    monkeypatch.setattr(neo4j_manager, "connect", AsyncMock())
+    monkeypatch.setattr(neo4j_manager, "create_db_schema", AsyncMock())
+    monkeypatch.setattr(neo4j_manager, "close", AsyncMock())
+    monkeypatch.setattr(orch.kg_maintainer_agent, "load_schema_from_db", AsyncMock())
+    monkeypatch.setattr(orch, "async_init_orchestrator", AsyncMock())
+    monkeypatch.setattr(orch, "perform_initial_setup", AsyncMock(return_value=True))
+    monkeypatch.setattr(orch.kg_maintainer_agent, "heal_and_enrich_kg", AsyncMock())
+    monkeypatch.setattr(
+        chapter_queries, "load_chapter_count_from_db", AsyncMock(return_value=3)
+    )
+    monkeypatch.setattr(orch.display, "start", lambda: None)
+    monkeypatch.setattr(orch.display, "stop", AsyncMock())
+    monkeypatch.setattr(orch, "_validate_critical_configs", lambda: True)
+
+    await orch.run_novel_generation_loop()
+
+    assert calls == [1, 2, 3]
+    assert orch.chapter_count == 3


### PR DESCRIPTION
## Summary
- adjust run loop to recalc remaining plot points each chapter
- test dynamic chapter targeting
- clarify CHAPTERS_PER_RUN behavior in README and .env.example

## Testing
- `ruff format --check .`
- `ruff check .`
- `pytest tests/ -v --cov=. --cov-report=term-missing`
- `mypy .` *(fails: Module has no attribute MAX_REVISION_CYCLES_PER_CHAPTER, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6854fb9e8fdc832f9e2da9cef999a6bc