### PR TITLE
Fix world ID handling in revision logic

### DIFF
--- a/processing/revision_logic.py
+++ b/processing/revision_logic.py
@@ -1004,7 +1004,11 @@ async def revise_chapter_draft_logic(
     use_patched_text_as_final = False
     if patched_text is not None and patched_text != original_text:
         evaluator = ComprehensiveEvaluatorAgent()
-        world_ids = {k: list(v.keys()) for k, v in world_building.items()}
+        world_ids = {
+            cat: [item.id for item in items.values() if isinstance(item, WorldItem)]
+            for cat, items in world_building.items()
+            if isinstance(items, dict)
+        }
         plot_focus, plot_idx = _get_plot_point_info(plot_outline, chapter_number)
         post_eval, post_usage = await evaluator.evaluate_chapter_draft(
             plot_outline,

--- a/tests/test_data_access_single_fetch.py
+++ b/tests/test_data_access_single_fetch.py
@@ -5,6 +5,7 @@ import pytest
 import utils
 from data_access import character_queries, world_queries
 from kg_constants import KG_NODE_CREATED_CHAPTER
+from kg_maintainer.models import WorldItem
 
 
 @pytest.mark.asyncio
@@ -123,3 +124,59 @@ async def test_get_world_item_by_id_fallback(monkeypatch):
     assert item.id == "places_city"
 
     world_queries.get_world_item_by_id.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_sync_world_items_populates_name_to_id(monkeypatch):
+    world_item = WorldItem.from_dict("Places", "City", {"description": "desc"})
+    world_data = {"Places": {"City": world_item}}
+
+    monkeypatch.setattr(
+        world_queries,
+        "generate_world_element_node_cypher",
+        lambda *_args, **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        world_queries.neo4j_manager,
+        "execute_cypher_batch",
+        AsyncMock(return_value=None),
+    )
+
+    world_queries.WORLD_NAME_TO_ID.clear()
+    await world_queries.sync_world_items(world_data, 1)
+    assert (
+        world_queries.WORLD_NAME_TO_ID[utils._normalize_for_id("City")] == world_item.id
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_world_building_from_db_populates_name_to_id(monkeypatch):
+    async def fake_read(query, params=None):
+        if "RETURN wc" in query:
+            return [{"wc": {"overview_description": "desc"}}]
+        if "RETURN we" in query:
+            return [
+                {
+                    "we": {
+                        "id": "places_city",
+                        "name": "City",
+                        "category": "places",
+                        "created_ts": 1,
+                        KG_NODE_CREATED_CHAPTER: 1,
+                    }
+                }
+            ]
+        return []
+
+    monkeypatch.setattr(
+        world_queries.neo4j_manager,
+        "execute_read_query",
+        AsyncMock(side_effect=fake_read),
+    )
+
+    world_queries.WORLD_NAME_TO_ID.clear()
+    world_data = await world_queries.get_world_building_from_db()
+    assert world_data["places"]["City"].id == "places_city"
+    assert (
+        world_queries.WORLD_NAME_TO_ID[utils._normalize_for_id("City")] == "places_city"
+    )

--- a/tests/test_revision_world_ids.py
+++ b/tests/test_revision_world_ids.py
@@ -1,0 +1,59 @@
+import pytest
+from unittest.mock import AsyncMock
+
+from kg_maintainer.models import WorldItem
+import processing.revision_logic as revision_logic
+from agents.comprehensive_evaluator_agent import ComprehensiveEvaluatorAgent
+
+
+@pytest.mark.asyncio
+async def test_revision_logic_passes_canonical_world_ids(monkeypatch):
+    world_item = WorldItem.from_dict("Places", "City", {"description": "d"})
+    world_building = {"Places": {"City": world_item}}
+    eval_result = {
+        "needs_revision": True,
+        "problems_found": [
+            {
+                "issue_category": "style",
+                "problem_description": "d",
+                "quote_from_original_text": "Hello",
+                "sentence_char_start": 0,
+                "sentence_char_end": 5,
+                "suggested_fix_focus": "fix",
+            }
+        ],
+    }
+
+    async def fake_generate(*_args, **_kwargs):
+        return [
+            {"target_char_start": 0, "target_char_end": 5, "replace_with": "Hi"}
+        ], None
+
+    async def fake_apply(*_args, **_kwargs):
+        return "Hi world", [(0, 5)]
+
+    async def fake_evaluate(*args, **kwargs):
+        assert args[2] == {"Places": [world_item.id]}
+        return {"problems_found": []}, None
+
+    monkeypatch.setattr(
+        revision_logic, "_generate_patch_instructions_logic", fake_generate
+    )
+    monkeypatch.setattr(revision_logic, "_apply_patches_to_text", fake_apply)
+    monkeypatch.setattr(
+        ComprehensiveEvaluatorAgent,
+        "evaluate_chapter_draft",
+        AsyncMock(side_effect=fake_evaluate),
+    )
+
+    res, _ = await revision_logic.revise_chapter_draft_logic(
+        {},
+        {},
+        world_building,
+        "Hello world",
+        1,
+        eval_result,
+        "",
+        None,
+    )
+    assert res is not None


### PR DESCRIPTION
## Summary
- ensure canonical world item IDs are passed to the evaluator during chapter revision
- keep `WORLD_NAME_TO_ID` updated when syncing world items and when loading them from Neo4j
- add tests for new mapping behavior and for revision logic

## Testing
- `ruff check .`
- `ruff format --check .`
- `mypy .` *(fails: Module has no attribute errors)*
- `pytest tests/ -v --cov=. --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_685576b65ae0832fa1bb902112bad8d9