### PR TITLE
Add dynamic relationship resolution and context pruning

### DIFF
--- a/agents/kg_maintainer_agent.py
+++ b/agents/kg_maintainer_agent.py
@@ -444,6 +444,9 @@ class KGMaintainerAgent:
         # 3. Entity Resolution
         await self._run_entity_resolution()
 
+        # 4. Dynamic Relationship Type Resolution
+        await self._resolve_dynamic_relationships()
+
         logger.info("KG Healer/Enricher: Maintenance cycle complete.")
 
     async def _find_and_enrich_thin_nodes(self) -> List[Tuple[str, Dict[str, Any]]]:
@@ -678,6 +681,54 @@ class KGMaintainerAgent:
             except (json.JSONDecodeError, TypeError) as e:
                 logger.error(
                     f"Failed to parse entity resolution response from LLM for pair ({id1}, {id2}): {e}. Response: {llm_response}"
+                )
+
+    async def _resolve_dynamic_relationships(self) -> None:
+        """Resolve generic DYNAMIC_REL types into clearer predicates."""
+        logger.info("KG Healer: Resolving dynamic relationship types...")
+        candidates = await kg_queries.get_dynamic_rels_for_resolution()
+
+        if not candidates:
+            logger.info("KG Healer: No dynamic relationships require resolution.")
+            return
+
+        template = Template(
+            render_prompt(
+                "kg_maintainer_agent/resolve_dynamic_rel.j2",
+                {},
+            )
+        )
+
+        for cand in candidates:
+            prompt = template.render(
+                subject=cand.get("subject_name"),
+                object=cand.get("object_name"),
+                current_type=cand.get("current_type"),
+            )
+            llm_resp, _ = await llm_service.async_call_llm(
+                model_name=config.SMALL_MODEL,
+                prompt=prompt,
+                temperature=0.3,
+                max_tokens=16,
+                allow_fallback=True,
+                auto_clean_response=True,
+            )
+            try:
+                data = json.loads(llm_resp)
+                new_type = data.get("resolved_type")
+                if new_type and isinstance(new_type, str):
+                    normalized = kg_queries.normalize_relationship_type(new_type)
+                    await kg_queries.update_dynamic_rel_type(cand["rel_id"], normalized)
+                    logger.info(
+                        "Updated relationship %s -> %s from %s to %s",
+                        cand.get("subject_name"),
+                        cand.get("object_name"),
+                        cand.get("current_type"),
+                        normalized,
+                    )
+            except json.JSONDecodeError:
+                logger.error(
+                    "Failed to parse dynamic relation resolution response: %s", llm_resp
                 )
 
     async def heal_schema(self) -> None:

--- a/prompt_data_getters.py
+++ b/prompt_data_getters.py
@@ -800,6 +800,18 @@ async def get_reliable_kg_facts_for_drafting_prompt(
         f"KG fact gathering for Ch {chapter_number} draft: Chars of interest: {characters_of_interest}, KG chapter limit: {kg_chapter_limit}"
     )
 
+    # Add shortest path facts from protagonist to other key characters
+    if protagonist_name:
+        for other in [c for c in characters_of_interest if c != protagonist_name][:2]:
+            path_triples = await kg_queries.get_shortest_path_triples_between_entities(
+                protagonist_name, other
+            )
+            if path_triples:
+                path_desc = path_triples[0]["subject"]
+                for t in path_triples:
+                    path_desc += f" -{t['predicate']}-> {t['object']}"
+                facts_for_prompt_list.append(f"- Path {path_desc}.")
+
     for desc_key in ["theme", "central_conflict"]:
         if len(facts_for_prompt_list) >= max_total_facts:
             break

--- a/prompts/kg_maintainer_agent/resolve_dynamic_rel.j2
+++ b/prompts/kg_maintainer_agent/resolve_dynamic_rel.j2
@@ -1,0 +1,7 @@
+You are an expert curator refining relationship types in a story knowledge graph.
+Given the subject and object names and the current vague relationship type, return a clearer predicate in UPPER_SNAKE_CASE. If uncertain, respond with "RELATED_TO".
+Respond in JSON with a single key `resolved_type`.
+Subject: {{ subject }}
+Object: {{ object }}
+Current type: {{ current_type }}
+

--- a/tests/test_context_pruning.py
+++ b/tests/test_context_pruning.py
@@ -1,0 +1,45 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from data_access import kg_queries
+from kg_maintainer.models import SceneDetail
+from prompt_data_getters import get_reliable_kg_facts_for_drafting_prompt
+
+
+@pytest.mark.asyncio
+async def test_get_reliable_kg_facts_adds_path(monkeypatch):
+    async def fake_get_property(key):
+        return None
+
+    monkeypatch.setattr(
+        kg_queries,
+        "get_novel_info_property_from_db",
+        AsyncMock(side_effect=fake_get_property),
+    )
+    monkeypatch.setattr(
+        kg_queries,
+        "get_most_recent_value_from_db",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(
+        kg_queries,
+        "query_kg_from_db",
+        AsyncMock(return_value=[]),
+    )
+
+    async def fake_path(src, tgt, max_depth=4):
+        return [
+            {"subject": src, "predicate": "KNOWS", "object": tgt},
+        ]
+
+    monkeypatch.setattr(
+        kg_queries,
+        "get_shortest_path_triples_between_entities",
+        AsyncMock(side_effect=fake_path),
+    )
+
+    outline = {"protagonist_name": "Alice"}
+    plan = [SceneDetail(scene_number=1, summary="", characters_involved=["Bob"])]
+    result = await get_reliable_kg_facts_for_drafting_prompt(outline, 2, plan)
+    assert "Path Alice -KNOWS-> Bob" in result

--- a/tests/test_dynamic_rel_resolution.py
+++ b/tests/test_dynamic_rel_resolution.py
@@ -1,0 +1,45 @@
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from agents.kg_maintainer_agent import KGMaintainerAgent
+from core.llm_interface import llm_service
+from data_access import kg_queries
+
+
+@pytest.mark.asyncio
+async def test_resolve_dynamic_relationships(monkeypatch):
+    agent = KGMaintainerAgent()
+
+    monkeypatch.setattr(
+        kg_queries,
+        "get_dynamic_rels_for_resolution",
+        AsyncMock(
+            return_value=[
+                {
+                    "rel_id": 1,
+                    "subject_name": "Alice",
+                    "object_name": "Bob",
+                    "current_type": "met",
+                }
+            ]
+        ),
+    )
+
+    updated: list = []
+
+    async def fake_update(rid, new_type):
+        updated.append((rid, new_type))
+
+    monkeypatch.setattr(
+        kg_queries, "update_dynamic_rel_type", AsyncMock(side_effect=fake_update)
+    )
+
+    async def fake_call(**_):
+        return json.dumps({"resolved_type": "MET_AT"}), None
+
+    monkeypatch.setattr(llm_service, "async_call_llm", fake_call)
+
+    await agent._resolve_dynamic_relationships()
+    assert updated == [(1, "MET_AT")]


### PR DESCRIPTION
## Summary
- enhance KG maintainer to resolve `DYNAMIC_REL` types using a new prompt
- add helper queries for relationship resolution and shortest-path facts
- prune drafting context by including shortest paths between protagonists and plan characters
- add tests for dynamic relation resolution and context pruning

## Testing
- `ruff check .`
- `ruff format --check .`
- `pytest tests/test_dynamic_rel_resolution.py tests/test_context_pruning.py -v --cov=. --cov-report=term-missing`
- `mypy .` *(fails: Module has no attribute errors)*

------
https://chatgpt.com/codex/tasks/task_e_6855b47dfd78832facf37d4c2ae1733a