### PR TITLE
feat(kg): resolve dynamic rels and prune context

### DIFF
--- a/data_access/__init__.py
+++ b/data_access/__init__.py
@@ -67,4 +67,7 @@ __all__ = [
     "normalize_existing_relationship_types",
     "get_most_recent_value_from_db",
     "get_novel_info_property_from_db",
+    "fetch_unresolved_dynamic_relationships",
+    "update_dynamic_relationship_type",
+    "get_shortest_path_length_between_entities",
 ]

--- a/prompt_data_getters.py
+++ b/prompt_data_getters.py
@@ -800,6 +800,19 @@ async def get_reliable_kg_facts_for_drafting_prompt(
         f"KG fact gathering for Ch {chapter_number} draft: Chars of interest: {characters_of_interest}, KG chapter limit: {kg_chapter_limit}"
     )
 
+    if protagonist_name and characters_of_interest:
+        pruned: Set[str] = set()
+        for c in characters_of_interest:
+            if c == protagonist_name:
+                pruned.add(c)
+                continue
+            path_len = await kg_queries.get_shortest_path_length_between_entities(
+                protagonist_name, c
+            )
+            if path_len is not None and path_len <= 3:
+                pruned.add(c)
+        characters_of_interest = pruned
+
     for desc_key in ["theme", "central_conflict"]:
         if len(facts_for_prompt_list) >= max_total_facts:
             break

--- a/tests/test_kg_heal.py
+++ b/tests/test_kg_heal.py
@@ -69,3 +69,64 @@ async def test_deduplicate_relationships(monkeypatch):
 
     removed = await kg_queries.deduplicate_relationships()
     assert removed == 1
+
+
+@pytest.mark.asyncio
+async def test_fetch_unresolved_dynamic_relationships(monkeypatch):
+    sample = [
+        {
+            "rel_id": 1,
+            "subject": "Alice",
+            "subject_labels": ["Character"],
+            "subject_desc": "brave hero",
+            "object": "Bob",
+            "object_labels": ["Character"],
+            "object_desc": "villain",
+            "type": "UNKNOWN",
+        }
+    ]
+
+    async def fake_read(query, params=None):
+        assert "UNKNOWN" in query
+        return sample
+
+    monkeypatch.setattr(
+        kg_queries.neo4j_manager,
+        "execute_read_query",
+        AsyncMock(side_effect=fake_read),
+    )
+
+    results = await kg_queries.fetch_unresolved_dynamic_relationships()
+    assert results == sample
+
+
+@pytest.mark.asyncio
+async def test_update_dynamic_relationship_type(monkeypatch):
+    executed = []
+
+    async def fake_write(query, params=None):
+        executed.append(params)
+
+    monkeypatch.setattr(
+        kg_queries.neo4j_manager,
+        "execute_write_query",
+        AsyncMock(side_effect=fake_write),
+    )
+
+    await kg_queries.update_dynamic_relationship_type(5, "ALLY_OF")
+    assert executed and executed[0]["id"] == 5 and executed[0]["type"] == "ALLY_OF"
+
+
+@pytest.mark.asyncio
+async def test_get_shortest_path_length_between_entities(monkeypatch):
+    async def fake_read(query, params=None):
+        return [{"len": 2}]
+
+    monkeypatch.setattr(
+        kg_queries.neo4j_manager,
+        "execute_read_query",
+        AsyncMock(side_effect=fake_read),
+    )
+
+    length = await kg_queries.get_shortest_path_length_between_entities("Alice", "Bob")
+    assert length == 2


### PR DESCRIPTION
## Summary
- interpret dynamic `DYNAMIC_REL` edges with a small LLM to resolve them to specific predicates
- expose new KG utilities for fetching unresolved relations and computing shortest paths
- prune KG context for prompts by ignoring characters too distant from the protagonist
- test new KG healing utilities

## Testing
- `ruff check . && ruff format --check .`
- `mypy .` *(fails: Module has no attribute errors)*
- `pytest tests/ -v --cov=. --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_6855b89477ac832fa806f258678cc9c2