### PR TITLE
Integrate dynamic plot point updates

### DIFF
--- a/agents/kg_maintainer_agent.py
+++ b/agents/kg_maintainer_agent.py
@@ -14,6 +14,7 @@ from core.llm_interface import llm_service
 from data_access import (
     character_queries,
     kg_queries,
+    plot_queries,
     world_queries,
 )
 
@@ -191,6 +192,10 @@ class KGMaintainerAgent:
         await world_queries.sync_world_items(
             world_items_to_persist, chapter_number_for_delta, full_sync=full_sync
         )
+
+    async def add_plot_point(self, description: str, prev_plot_point_id: str) -> str:
+        """Persist a new plot point and link it in sequence."""
+        return await plot_queries.append_plot_point(description, prev_plot_point_id)
 
     async def summarize_chapter(
         self, chapter_text: Optional[str], chapter_number: int

--- a/data_access/__init__.py
+++ b/data_access/__init__.py
@@ -27,7 +27,11 @@ from .kg_queries import (
     normalize_existing_relationship_types,
     query_kg_from_db,
 )
-from .plot_queries import get_plot_outline_from_db, save_plot_outline_to_db
+from .plot_queries import (
+    get_plot_outline_from_db,
+    save_plot_outline_to_db,
+    append_plot_point,
+)
 from .world_queries import (
     get_world_building_from_db,
     get_world_elements_for_snippet_from_db,
@@ -43,6 +47,7 @@ from .world_queries import (
 __all__ = [
     "save_plot_outline_to_db",
     "get_plot_outline_from_db",
+    "append_plot_point",
     "sync_characters_full_state_from_object_to_db",
     "sync_characters",
     "get_character_profile_by_name",

--- a/orchestration/nana_orchestrator.py
+++ b/orchestration/nana_orchestrator.py
@@ -118,6 +118,15 @@ class NANA_Orchestrator:
         }
         self._update_rich_display()
 
+    async def refresh_plot_outline(self) -> None:
+        """Reload plot outline from the database."""
+        result = await plot_queries.get_plot_outline_from_db()
+        if isinstance(result, dict):
+            self.plot_outline = result
+            self._update_novel_props_cache()
+        else:
+            logger.error("Failed to refresh plot outline from DB: %s", result)
+
     async def async_init_orchestrator(self):
         logger.info("NANA Orchestrator async_init_orchestrator started...")
         self._update_rich_display(step="Initializing Orchestrator")
@@ -1159,6 +1168,7 @@ class NANA_Orchestrator:
                                     step=f"Ch {current_novel_chapter_number} - KG Maintenance"
                                 )
                                 await self.kg_maintainer_agent.heal_and_enrich_kg()
+                                await self.refresh_plot_outline()
                                 logger.info(
                                     "--- NANA: KG Healing/Enrichment cycle complete. ---"
                                 )

--- a/tests/test_novel_generation_dynamic.py
+++ b/tests/test_novel_generation_dynamic.py
@@ -39,6 +39,7 @@ async def test_dynamic_chapter_adjustment(monkeypatch):
     monkeypatch.setattr(orch, "async_init_orchestrator", AsyncMock())
     monkeypatch.setattr(orch, "perform_initial_setup", AsyncMock(return_value=True))
     monkeypatch.setattr(orch.kg_maintainer_agent, "heal_and_enrich_kg", AsyncMock())
+    monkeypatch.setattr(orch, "refresh_plot_outline", AsyncMock())
     monkeypatch.setattr(
         chapter_queries, "load_chapter_count_from_db", AsyncMock(return_value=3)
     )

--- a/tests/test_orchestrator_refresh.py
+++ b/tests/test_orchestrator_refresh.py
@@ -1,0 +1,25 @@
+import pytest
+from unittest.mock import AsyncMock
+
+from data_access import plot_queries
+from orchestration.nana_orchestrator import NANA_Orchestrator
+import utils
+
+
+@pytest.fixture
+def orchestrator(monkeypatch):
+    monkeypatch.setattr(utils, "load_spacy_model_if_needed", lambda: None)
+    orch = NANA_Orchestrator()
+    monkeypatch.setattr(orch, "_update_rich_display", lambda *a, **k: None)
+    return orch
+
+
+@pytest.mark.asyncio
+async def test_refresh_plot_outline(orchestrator, monkeypatch):
+    monkeypatch.setattr(
+        plot_queries,
+        "get_plot_outline_from_db",
+        AsyncMock(return_value={"plot_points": ["a", "b"]}),
+    )
+    await orchestrator.refresh_plot_outline()
+    assert orchestrator.plot_outline["plot_points"] == ["a", "b"]

--- a/tests/test_plot_queries_append.py
+++ b/tests/test_plot_queries_append.py
@@ -1,0 +1,35 @@
+import pytest
+from unittest.mock import AsyncMock
+
+import config
+from data_access import plot_queries
+
+
+@pytest.mark.asyncio
+async def test_append_plot_point(monkeypatch):
+    async def fake_read(query, params=None):
+        assert "max(pp.sequence)" in query
+        return [{"max_seq": 2}]
+
+    executed = []
+
+    async def fake_batch(statements):
+        executed.extend(statements)
+
+    monkeypatch.setattr(
+        plot_queries.neo4j_manager,
+        "execute_read_query",
+        AsyncMock(side_effect=fake_read),
+    )
+    monkeypatch.setattr(
+        plot_queries.neo4j_manager,
+        "execute_cypher_batch",
+        AsyncMock(side_effect=fake_batch),
+    )
+
+    new_id = await plot_queries.append_plot_point(
+        "New", "pp_{}_2".format(config.MAIN_NOVEL_INFO_NODE_ID)
+    )
+
+    assert new_id == f"pp_{config.MAIN_NOVEL_INFO_NODE_ID}_3"
+    assert executed


### PR DESCRIPTION
## Summary
- expose `append_plot_point` helper in `plot_queries`
- allow `KGMaintainerAgent` to add new plot points
- refresh plot outline in `NANA_Orchestrator` after KG healing
- add tests for plot point append and outline refresh
- adjust dynamic chapter test for new refresh hook

## Testing
- `ruff check . && ruff format --check .`
- `pytest tests/ -v --cov=. --cov-report=term-missing`
- `mypy .` *(fails: Module has no attribute errors)*

------
https://chatgpt.com/codex/tasks/task_e_6855c1375770832fbc17f3644434ebd0