### PR TITLE
Add ingestion mode for SAGA

### DIFF
--- a/agents/finalize_agent.py
+++ b/agents/finalize_agent.py
@@ -224,3 +224,22 @@ class FinalizeAgent:
             "summary_usage": summary_usage,
             "kg_usage": kg_usage,
         }
+
+    async def ingest_and_finalize_chunk(
+        self,
+        plot_outline: Dict[str, Any],
+        character_profiles: Dict[str, CharacterProfile],
+        world_building: Dict[str, Dict[str, WorldItem]],
+        chunk_number: int,
+        chunk_text: str,
+    ) -> FinalizationResult:
+        """Finalize an ingested text chunk using the regular pipeline."""
+        return await self.finalize_chapter(
+            plot_outline,
+            character_profiles,
+            world_building,
+            chunk_number,
+            chunk_text,
+            raw_llm_output=None,
+            from_flawed_draft=False,
+        )

--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+import argparse
 import asyncio
 import logging
 
@@ -9,9 +10,16 @@ logger = logging.getLogger(__name__)
 
 def main() -> None:
     setup_logging_nana()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ingest", default=None, help="Path to text file to ingest")
+    args = parser.parse_args()
+
     orchestrator = NANA_Orchestrator()
     try:
-        asyncio.run(orchestrator.run_novel_generation_loop())
+        if args.ingest:
+            asyncio.run(orchestrator.run_ingestion_process(args.ingest))
+        else:
+            asyncio.run(orchestrator.run_novel_generation_loop())
     except KeyboardInterrupt:
         logger.info(
             "NANA Orchestrator shutting down gracefully due to KeyboardInterrupt..."

--- a/prompts/planner_agent/plan_continuation.j2
+++ b/prompts/planner_agent/plan_continuation.j2
@@ -1,0 +1,7 @@
+/no_think
+You are a master storyteller. Based on the provided summary, propose {{ num_points }} succinct future plot points for how the story could continue.
+Return only a JSON array of strings.
+
+Summary:
+{{ summary }}
+

--- a/tests/test_ingestion_mode.py
+++ b/tests/test_ingestion_mode.py
@@ -1,0 +1,36 @@
+import pytest
+from agents.finalize_agent import FinalizeAgent
+from agents.planner_agent import PlannerAgent
+from core.llm_interface import llm_service
+from utils.ingestion_utils import split_text_into_chapters
+
+
+def test_split_text_into_chapters_basic():
+    text = "p1\n\npara2 longer\n\npara3\n\npara4"
+    chapters = split_text_into_chapters(text, max_chars=20)
+    assert chapters == ["p1\n\npara2 longer", "para3\n\npara4"]
+
+
+@pytest.mark.asyncio
+async def test_ingest_and_finalize_chunk_delegates(monkeypatch):
+    agent = FinalizeAgent()
+
+    async def fake_finalize(*args, **kwargs):
+        return {"summary": "done"}
+
+    monkeypatch.setattr(agent, "finalize_chapter", fake_finalize)
+    result = await agent.ingest_and_finalize_chunk({}, {}, {}, 1, "text")
+    assert result["summary"] == "done"
+
+
+@pytest.mark.asyncio
+async def test_plan_continuation_parses(monkeypatch):
+    agent = PlannerAgent()
+
+    async def fake_llm(*_a, **_k):
+        return '["a", "b"]', {"total_tokens": 1}
+
+    monkeypatch.setattr(llm_service, "async_call_llm", fake_llm)
+    points, usage = await agent.plan_continuation("sum", 2)
+    assert points == ["a", "b"]
+    assert usage == {"total_tokens": 1}

--- a/utils/ingestion_utils.py
+++ b/utils/ingestion_utils.py
@@ -1,0 +1,24 @@
+import config
+from typing import List
+
+
+def split_text_into_chapters(
+    text: str, max_chars: int = config.MIN_ACCEPTABLE_DRAFT_LENGTH
+) -> List[str]:
+    """Split text into pseudo-chapters by paragraph boundaries."""
+    paragraphs = text.split("\n\n")
+    chapters: List[str] = []
+    current: List[str] = []
+    current_length = 0
+    for para in paragraphs:
+        para_len = len(para) + 2
+        if current_length + para_len > max_chars and current:
+            chapters.append("\n\n".join(current).strip())
+            current = [para]
+            current_length = para_len
+        else:
+            current.append(para)
+            current_length += para_len
+    if current:
+        chapters.append("\n\n".join(current).strip())
+    return [c for c in chapters if c.strip()]


### PR DESCRIPTION
## Summary
- implement `split_text_into_chapters` utility
- add `ingest_and_finalize_chunk` to `FinalizeAgent`
- allow `PlannerAgent` to plan continuation plot points
- add ingestion workflow in `NANA_Orchestrator`
- expose `--ingest` CLI flag
- include new prompt and tests

## Testing
- `ruff check .`
- `ruff format --check .`
- `pytest tests/ -v --cov=. --cov-report=term-missing`
- `mypy .` *(fails: module attribute errors)*

------
https://chatgpt.com/codex/tasks/task_e_6855dd44615c832fb932e498b1e16306