### PR TITLE
Fix DB resume bug

### DIFF
--- a/core/db_manager.py
+++ b/core/db_manager.py
@@ -210,13 +210,13 @@ class Neo4jManagerSingleton:
         # and immediately deleting a dummy node/relationship is sufficient.
         relationship_type_queries = [
             (
-                f"MERGE (a:__RelTypePlaceholder)-[:{rel_type}]->"
-                f"(b:__RelTypePlaceholder) DETACH DELETE a,b"
+                f"CREATE (a:__RelTypePlaceholder)-[:{rel_type}]->"
+                f"(b:__RelTypePlaceholder) WITH a,b DETACH DELETE a,b"
             )
             for rel_type in RELATIONSHIP_TYPES
         ]
         node_label_queries = [
-            f"MERGE (a:`{label}`) DETACH DELETE a" for label in NODE_LABELS
+            f"CREATE (a:`{label}`) WITH a DELETE a" for label in NODE_LABELS
         ]
 
         vector_index_query = f"""


### PR DESCRIPTION
## Summary
- stop deleting existing nodes when verifying Neo4j schema

## Testing
- `ruff check .`
- `ruff format --check .`
- `pytest tests/ -v --cov=. --cov-report=term-missing`
- `mypy .` *(fails: Library stubs not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6855e3fdde44832f84c24eb6eebca8bd