### PR TITLE
Enable KG healing during ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,16 @@ Using a local setup with the following GGUF models:
 
 SAGA can generate a batch of **3 chapters** (each ~13,000+ tokens of narrative) in approximately **11 minutes**, involving significant processing for planning, context generation, evaluation, and knowledge graph updates.
 
+### Ingestion Mode
+
+To import existing text into the knowledge graph:
+
+```bash
+python main.py --ingest path/to/novel.txt
+```
+
+The text is split into pseudo-chapters and processed through the finalization pipeline. The knowledge graph heals every `KG_HEALING_INTERVAL` chapters during ingestion so later chapters see a deduplicated graph.
+
 ## Resetting the Database
 
 To start SAGA from a completely fresh state:

--- a/orchestration/nana_orchestrator.py
+++ b/orchestration/nana_orchestrator.py
@@ -1261,6 +1261,14 @@ class NANA_Orchestrator:
                 summaries.append(str(result["summary"]))
                 plot_outline["plot_points"].append(result["summary"])
 
+            if idx % config.KG_HEALING_INTERVAL == 0:
+                logger.info(
+                    f"--- NANA: Triggering KG Healing/Enrichment after Ingestion Chunk {idx} ---"
+                )
+                self._update_rich_display(step=f"Ch {idx} - KG Maintenance")
+                await self.kg_maintainer_agent.heal_and_enrich_kg()
+                await self.refresh_plot_outline()
+
         await self.kg_maintainer_agent.heal_and_enrich_kg()
         combined_summary = "\n".join(summaries)
         continuation, _ = await self.planner_agent.plan_continuation(combined_summary)

--- a/tests/test_ingestion_healing.py
+++ b/tests/test_ingestion_healing.py
@@ -1,0 +1,54 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+import config
+import utils
+from core.db_manager import neo4j_manager
+from data_access import plot_queries
+from orchestration.nana_orchestrator import NANA_Orchestrator
+
+
+@pytest.mark.asyncio
+async def test_ingestion_triggers_healing(monkeypatch, tmp_path):
+    monkeypatch.setattr(utils, "load_spacy_model_if_needed", lambda: None)
+    monkeypatch.setattr(config, "KG_HEALING_INTERVAL", 2)
+
+    orch = NANA_Orchestrator()
+    monkeypatch.setattr(orch, "_update_rich_display", lambda *a, **k: None)
+
+    chapters = ["a", "b", "c", "d", "e"]
+
+    monkeypatch.setattr(
+        "orchestration.nana_orchestrator.split_text_into_chapters", lambda _t: chapters
+    )
+    monkeypatch.setattr(
+        orch.finalize_agent,
+        "ingest_and_finalize_chunk",
+        AsyncMock(return_value={"summary": "s"}),
+    )
+    heal = AsyncMock()
+    monkeypatch.setattr(orch.kg_maintainer_agent, "heal_and_enrich_kg", heal)
+    monkeypatch.setattr(
+        orch.planner_agent, "plan_continuation", AsyncMock(return_value=(None, {}))
+    )
+
+    monkeypatch.setattr(orch.display, "start", lambda: None)
+    monkeypatch.setattr(orch.display, "stop", AsyncMock())
+    monkeypatch.setattr(neo4j_manager, "connect", AsyncMock())
+    monkeypatch.setattr(neo4j_manager, "create_db_schema", AsyncMock())
+    monkeypatch.setattr(neo4j_manager, "close", AsyncMock())
+    monkeypatch.setattr(orch.kg_maintainer_agent, "load_schema_from_db", AsyncMock())
+    monkeypatch.setattr(plot_queries, "save_plot_outline_to_db", AsyncMock())
+    monkeypatch.setattr(
+        plot_queries,
+        "get_plot_outline_from_db",
+        AsyncMock(return_value={"plot_points": []}),
+    )
+
+    text_file = tmp_path / "novel.txt"
+    text_file.write_text("dummy")
+
+    await orch.run_ingestion_process(str(text_file))
+
+    assert heal.call_count == 3


### PR DESCRIPTION
## Summary
- heal the knowledge graph after every `KG_HEALING_INTERVAL` chapters when ingesting text
- add test covering incremental healing
- document ingestion mode in README

## Testing
- `ruff check .`
- `ruff format --check .`
- `pytest tests/ -v --cov=. --cov-report=term-missing`
- `mypy .` *(fails: multiple errors)*

------
https://chatgpt.com/codex/tasks/task_e_6855ed87452c832fbe714fb1ce835659