### PR TITLE
Fix fill-in detection and ingestion setup

### DIFF
--- a/main.py
+++ b/main.py
@@ -38,16 +38,14 @@ def main() -> None:
                 await neo4j_manager.close()
 
             try:
-                loop = asyncio.get_event_loop()
-                if loop.is_running() and not loop.is_closed():
-                    asyncio.ensure_future(_close_driver_main())
-                elif not loop.is_running() and not loop.is_closed():
-                    loop.run_until_complete(_close_driver_main())
-                else:
-                    asyncio.run(_close_driver_main())
-            except RuntimeError as e:
+                loop = asyncio.get_running_loop()
+                if not loop.is_closed():
+                    loop.create_task(_close_driver_main())
+            except RuntimeError:
+                asyncio.run(_close_driver_main())
+            except Exception as e:
                 logger.warning(
-                    "Could not explicitly close driver from main (event loop might be closed or other issue): %s",
+                    "Could not explicitly close driver from main: %s",
                     e,
                 )
 

--- a/orchestration/nana_orchestrator.py
+++ b/orchestration/nana_orchestrator.py
@@ -1290,6 +1290,10 @@ class NANA_Orchestrator:
         self.run_start_time = time.time()
         await neo4j_manager.connect()
         await neo4j_manager.create_db_schema()
+        if neo4j_manager.driver is not None:
+            await plot_queries.ensure_novel_info()
+        else:
+            logger.warning("Neo4j driver not initialized. Skipping NovelInfo setup.")
         await self.kg_maintainer_agent.load_schema_from_db()
 
         with open(text_file, "r", encoding="utf-8") as f:

--- a/orchestration/nana_orchestrator.py
+++ b/orchestration/nana_orchestrator.py
@@ -278,7 +278,7 @@ class NANA_Orchestrator:
     async def _save_chapter_text_and_log(
         self, chapter_number: int, final_text: str, raw_llm_log: Optional[str]
     ):
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         try:
             await loop.run_in_executor(
                 None,
@@ -321,7 +321,7 @@ class NANA_Orchestrator:
         content_str = str(content) if not isinstance(content, str) else content
         if not content_str.strip():
             return
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         try:
             safe_stage_desc = "".join(
                 c if c.isalnum() or c in ["_", "-"] else "_" for c in stage_description

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -3,4 +3,4 @@ import config
 
 def _is_fill_in(value: object) -> bool:
     """Return True if ``value`` equals the fill-in placeholder."""
-    return isinstance(value, str) and value == config.FILL_IN
+    return isinstance(value, str) and value.strip() == config.FILL_IN

--- a/utils/text_processing.py
+++ b/utils/text_processing.py
@@ -72,7 +72,7 @@ spacy_manager = SpaCyModelManager()
 
 def _is_fill_in(value: Any) -> bool:
     """Return True if ``value`` is the fill-in placeholder."""
-    return isinstance(value, str) and value == config.FILL_IN
+    return isinstance(value, str) and value.strip() == config.FILL_IN
 
 
 def load_spacy_model_if_needed() -> None:


### PR DESCRIPTION
## Summary
- strip whitespace in `_is_fill_in` helpers so placeholders are properly detected
- skip `ensure_novel_info` when Neo4j isn't connected during ingestion
- call `ensure_novel_info` during text ingestion when possible

## Testing
- `ruff check . && ruff format --check .`
- `pytest tests/ -v --cov=. --cov-report=term-missing`
- `mypy .` *(fails: multiple missing attributes)*

------
https://chatgpt.com/codex/tasks/task_e_6856dab00b8c832fad83aaca15d50bab