### PR TITLE
Implement scene plan validation

### DIFF
--- a/config.py
+++ b/config.py
@@ -201,6 +201,7 @@ class SagaSettings(BaseSettings):
     # Revision and Validation
     ENABLE_COMPREHENSIVE_EVALUATION: bool = True
     ENABLE_WORLD_CONTINUITY_CHECK: bool = True
+    ENABLE_SCENE_PLAN_VALIDATION: bool = True
     ENABLE_PATCH_BASED_REVISION: bool = True
     AGENT_ENABLE_PATCH_VALIDATION: bool = True
     MAX_PATCH_INSTRUCTIONS_TO_GENERATE: int = 5

--- a/orchestration/nana_orchestrator.py
+++ b/orchestration/nana_orchestrator.py
@@ -544,6 +544,33 @@ class NANA_Orchestrator:
 
         chapter_plan: Optional[List[SceneDetail]] = chapter_plan_result
 
+        if (
+            config.ENABLE_SCENE_PLAN_VALIDATION
+            and chapter_plan is not None
+            and config.ENABLE_WORLD_CONTINUITY_CHECK
+        ):
+            (
+                plan_problems,
+                usage,
+            ) = await self.world_continuity_agent.check_scene_plan_consistency(
+                self.plot_outline,
+                chapter_plan,
+                novel_chapter_number,
+            )
+            self._accumulate_tokens(
+                f"Ch{novel_chapter_number}-PlanConsistency",
+                usage,
+            )
+            await self._save_debug_output(
+                novel_chapter_number,
+                "scene_plan_consistency_problems",
+                plan_problems,
+            )
+            if plan_problems:
+                logger.warning(
+                    f"NANA: Ch {novel_chapter_number} scene plan has {len(plan_problems)} consistency issues."
+                )
+
         hybrid_context_for_draft = await generate_hybrid_chapter_context_logic(
             self, novel_chapter_number, chapter_plan
         )

--- a/prompts/world_continuity_agent/plan_consistency_check.j2
+++ b/prompts/world_continuity_agent/plan_consistency_check.j2
@@ -1,0 +1,49 @@
+/no_think
+You are a World & Continuity Expert Editor for Chapter {{ chapter_number }} of the novel "{{ novel_title }}" (Protagonist: {{ protagonist_name_str }}).
+Your SOLE TASK is to identify specific CONSISTENCY issues in the **Scene Plan** below. Focus on:
+- Contradictions with the Plot Outline summary.
+- Contradictions with Character Profiles (descriptions, established traits, known status, relationships).
+- Contradictions with World Building rules, descriptions, or established lore.
+- Internal inconsistencies of fact or established detail within this plan.
+
+**Reference Information for CONSISTENCY Check (Summary Format):**
+  **Plot Outline Summary:**
+  ```text
+  Title: {{ novel_title }}
+  Genre: {{ novel_genre }}
+  Theme: {{ novel_theme }}
+  Protagonist: {{ novel_protagonist }} ({{ protagonist_arc }})
+  Logline: {{ logline }}
+  Key Plot Points (summary):
+  {{ plot_points_summary_str }}
+  ```
+  **Character Profiles (Key Info - check 'prompt_notes' for provisional status):**
+  ```text
+  {{ char_profiles_plain_text }}
+  ```
+  **World Building Notes (Key Info - check 'prompt_notes' for provisional status):**
+  ```text
+  {{ world_building_plain_text }}
+  ```
+
+**Scene Plan to Analyze (JSON array):**
+```json
+{{ scene_plan_json }}
+```
+
+**Output Format (CRITICAL - JSON ONLY):**
+If consistency problems are found, output a JSON array of problem objects.
+Each object MUST have these keys: "issue_category" (fixed to "consistency"), "problem_description", "quote_from_original_text", "suggested_fix_focus".
+The `quote_from_original_text` should be a relevant snippet from the plan. If general or no quote applies, use "N/A - General Issue".
+If NO consistency problems are found, output an empty JSON array `[]` or a JSON object like {"status": "No significant consistency problems found"}.
+If any part of the reference material is unclear or incomplete, note the uncertainty in your problem descriptions.
+
+**Ignore the narrative details in the below example. It shows the required format only.**
+**Follow this example structure for your JSON output precisely:**
+```json
+{{ few_shot_consistency_example_str.strip() }}
+```
+**Ignore the narrative details in this example. It shows the required format only.**
+
+Begin your JSON output now:
+

--- a/tests/test_orchestrator_private_methods.py
+++ b/tests/test_orchestrator_private_methods.py
@@ -108,6 +108,11 @@ async def test_prepare_prerequisites_uses_plan(orchestrator, monkeypatch):
         AsyncMock(return_value={}),
     )
     monkeypatch.setattr(
+        orchestrator.world_continuity_agent,
+        "check_scene_plan_consistency",
+        AsyncMock(return_value=([], {})),
+    )
+    monkeypatch.setattr(
         "orchestration.nana_orchestrator.generate_hybrid_chapter_context_logic",
         AsyncMock(side_effect=fake_context),
     )

--- a/tests/test_world_continuity_agent.py
+++ b/tests/test_world_continuity_agent.py
@@ -42,3 +42,43 @@ async def test_check_consistency_passes_id_mapping(monkeypatch):
     await agent.check_consistency({"plot_points": []}, "draft", 1, "")
 
     assert received["ids"] == mapping
+
+
+@pytest.mark.asyncio
+async def test_check_scene_plan_consistency(monkeypatch):
+    agent = WorldContinuityAgent()
+
+    monkeypatch.setattr(
+        character_queries, "get_character_profiles_from_db", AsyncMock(return_value=[])
+    )
+    mapping = {"places": ["id2"]}
+    monkeypatch.setattr(
+        world_queries,
+        "get_all_world_item_ids_by_category",
+        AsyncMock(return_value=mapping),
+    )
+
+    received: dict = {}
+
+    async def fake_get_world(ids_by_cat, up_to):
+        received["ids"] = ids_by_cat
+        return ""
+
+    monkeypatch.setattr(
+        world_continuity_agent,
+        "get_filtered_world_data_for_prompt_plain_text",
+        fake_get_world,
+    )
+
+    monkeypatch.setattr(world_continuity_agent, "render_prompt", lambda *a, **k: "")
+    monkeypatch.setattr(
+        llm_service, "async_call_llm", AsyncMock(return_value=("[]", {}))
+    )
+
+    await agent.check_scene_plan_consistency(
+        {"plot_points": []},
+        [{"scene_number": 1}],
+        1,
+    )
+
+    assert received["ids"] == mapping


### PR DESCRIPTION
## Summary
- introduce `ENABLE_SCENE_PLAN_VALIDATION` flag
- add `WorldContinuityAgent.check_scene_plan_consistency`
- call new check when preparing chapter prerequisites
- cover new functionality with tests

## Testing
- `ruff check . && ruff format --check .`
- `pytest tests/ -v --cov=. --cov-report=term-missing`
- `mypy .` *(fails: Library stubs not installed for "yaml", plus 365 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6856f273c0e0832f8d98b184e2e4ac7c