### PR TITLE
Fix shortestPath query handling

### DIFF
--- a/config.py
+++ b/config.py
@@ -240,7 +240,9 @@ class SagaSettings(BaseSettings):
     UNHINGED_PLOT_MODE: bool = False
     CONFIGURED_GENRE: str = "grimdark science fiction"
     CONFIGURED_THEME: str = "the hubris of humanity"
-    CONFIGURED_SETTING_DESCRIPTION: str = "a remote outpost on the surface of Jupiter's moon, Callisto"
+    CONFIGURED_SETTING_DESCRIPTION: str = (
+        "a remote outpost on the surface of Jupiter's moon, Callisto"
+    )
     DEFAULT_PROTAGONIST_NAME: str = "Ilya Lakatos"
     DEFAULT_PLOT_OUTLINE_TITLE: str = "Untitled Narrative"
 

--- a/data_access/kg_queries.py
+++ b/data_access/kg_queries.py
@@ -727,14 +727,17 @@ async def get_shortest_path_length_between_entities(
     name1: str, name2: str, max_depth: int = 4
 ) -> Optional[int]:
     """Return the shortest path length between two entities if it exists."""
-    query = """
-    MATCH (a:Entity {name: $name1}), (b:Entity {name: $name2})
-    MATCH p = shortestPath((a)-[*..$max_depth]-(b))
+    if max_depth <= 0:
+        return None
+
+    query = f"""
+    MATCH (a:Entity {{name: $name1}}), (b:Entity {{name: $name2}})
+    MATCH p = shortestPath((a)-[*..{max_depth}]-(b))
     RETURN length(p) AS len
     """
     try:
         results = await neo4j_manager.execute_read_query(
-            query, {"name1": name1, "name2": name2, "max_depth": max_depth}
+            query, {"name1": name1, "name2": name2}
         )
         if results:
             return results[0].get("len")

--- a/tests/test_kg_heal.py
+++ b/tests/test_kg_heal.py
@@ -119,7 +119,11 @@ async def test_update_dynamic_relationship_type(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_get_shortest_path_length_between_entities(monkeypatch):
+    captured = {}
+
     async def fake_read(query, params=None):
+        captured["query"] = query
+        captured["params"] = params
         return [{"len": 2}]
 
     monkeypatch.setattr(
@@ -128,5 +132,11 @@ async def test_get_shortest_path_length_between_entities(monkeypatch):
         AsyncMock(side_effect=fake_read),
     )
 
-    length = await kg_queries.get_shortest_path_length_between_entities("Alice", "Bob")
+    length = await kg_queries.get_shortest_path_length_between_entities(
+        "Alice",
+        "Bob",
+        max_depth=3,
+    )
     assert length == 2
+    assert "[*..3]" in captured["query"]
+    assert captured["params"] == {"name1": "Alice", "name2": "Bob"}


### PR DESCRIPTION
## Summary
- adjust shortest path query to inline the max depth value
- record the query in tests to ensure depth is embedded
- fix formatting in `config.py`

## Testing
- `ruff check .`
- `ruff format --check .`
- `mypy .` *(fails: Module has no attribute...)*
- `pytest tests/ -v --cov=. --cov-report=term-missing`
- `pytest tests/test_kg_heal.py::test_get_shortest_path_length_between_entities -v`

------
https://chatgpt.com/codex/tasks/task_e_6857013bf254832fbbbc8ecba13b30e7