### PR TITLE
Add GPT-ism cleanup step

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ SAGA's NANA engine orchestrates a sophisticated pipeline for novel generation:
         *   The `DraftingAgent` writes the initial draft, guided by the scene plan (if available), plot point focus, and hybrid context.
     *   **(C) De-duplication & Evaluation:**
         *   The draft undergoes de-duplication via `processing.text_deduplicator` to reduce repetitiveness.
+        *   If `ENABLE_GPTISM_CLEANUP` is true, `processing.gptism_cleanup` replaces common LLM-style phrases with alternative wording.
         *   The `ComprehensiveEvaluatorAgent` and `WorldContinuityAgent` run in parallel to assess the draft against multiple criteria.
     *   **(D) Revision (if `needs_revision` is true):**
         *   `processing.revision_logic` attempts to fix identified issues.
@@ -146,7 +147,8 @@ SMALL_MODEL="Qwen3-4B-Q4"    # Used for Summaries
 NARRATOR_MODEL="Qwen3-14B-Q4" # Used for Drafting and a full Revision
 
 # Other important settings in config.py (review defaults)
-# MAX_CONTEXT_TOKENS, CHAPTERS_PER_RUN, LOG_LEVEL, etc.
+# MAX_CONTEXT_TOKENS, CHAPTERS_PER_RUN, LOG_LEVEL,
+# ENABLE_GPTISM_CLEANUP, GPTISM_SIMILARITY_THRESHOLD, etc.
 ```
 
 Refer to `config.py` for a full list of configurable options and their defaults.

--- a/config.py
+++ b/config.py
@@ -227,6 +227,10 @@ class SagaSettings(BaseSettings):
     DEDUPLICATION_SEMANTIC_THRESHOLD: float = 0.85
     DEDUPLICATION_MIN_SEGMENT_LENGTH: int = 150
 
+    # GPT-ism Cleanup Configuration
+    ENABLE_GPTISM_CLEANUP: bool = True
+    GPTISM_SIMILARITY_THRESHOLD: float = 85.0
+
     # Logging & UI
     LOG_LEVEL_STR: str = Field("INFO", alias="LOG_LEVEL")
     LOG_FORMAT: str = (

--- a/orchestration/nana_orchestrator.py
+++ b/orchestration/nana_orchestrator.py
@@ -384,6 +384,38 @@ class NANA_Orchestrator:
             )
             return text_to_dedup, 0
 
+    async def perform_gptism_cleanup(
+        self, text: str, chapter_number: int
+    ) -> Tuple[str, int]:
+        """Replace GPT-style phrases in ``text`` if enabled."""
+        if not config.ENABLE_GPTISM_CLEANUP:
+            return text, 0
+        if not text or not text.strip():
+            return text, 0
+
+        logger.info(f"NANA: Performing GPT-ism cleanup for Chapter {chapter_number}...")
+        try:
+            from processing.gptism_cleanup import replace_gptisms
+
+            cleaned, count = replace_gptisms(
+                text, threshold=config.GPTISM_SIMILARITY_THRESHOLD
+            )
+            if count > 0:
+                logger.info(
+                    f"GPT-ism cleanup for Chapter {chapter_number} replaced {count} phrase(s)."
+                )
+            else:
+                logger.info(
+                    f"GPT-ism cleanup for Chapter {chapter_number}: no changes."
+                )
+            return cleaned, count
+        except Exception as e:  # pragma: no cover - unexpected errors
+            logger.error(
+                f"Error during GPT-ism cleanup for Chapter {chapter_number}: {e}",
+                exc_info=True,
+            )
+            return text, 0
+
     async def _run_evaluation_cycle(
         self,
         novel_chapter_number: int,
@@ -661,19 +693,22 @@ class NANA_Orchestrator:
             deduplicated_text, removed_char_count = await self.perform_deduplication(
                 initial_draft_text, novel_chapter_number
             )
-            is_from_flawed_source_for_kg = removed_char_count > 0
+            cleaned_text, replaced = await self.perform_gptism_cleanup(
+                deduplicated_text, novel_chapter_number
+            )
+            is_from_flawed_source_for_kg = removed_char_count > 0 or replaced > 0
             if is_from_flawed_source_for_kg:
                 logger.info(
-                    f"NANA: Ch {novel_chapter_number} - Text marked as flawed for KG due to de-duplication removing {removed_char_count} characters."
+                    f"NANA: Ch {novel_chapter_number} - Text marked as flawed for KG due to cleaning removing/replacing text."
                 )
                 await self._save_debug_output(
                     novel_chapter_number,
                     "deduplicated_text_no_eval_path",
-                    deduplicated_text,
+                    cleaned_text,
                 )
 
             return (
-                deduplicated_text,
+                cleaned_text,
                 initial_raw_llm_text,
                 is_from_flawed_source_for_kg,
             )
@@ -696,12 +731,15 @@ class NANA_Orchestrator:
         ) = await self.perform_deduplication(
             current_text_to_process, novel_chapter_number
         )
-        if removed_char_count > 0:
+        cleaned_text, replaced = await self.perform_gptism_cleanup(
+            deduplicated_text, novel_chapter_number
+        )
+        if removed_char_count > 0 or replaced > 0:
             is_from_flawed_source_for_kg = True
             logger.info(
-                f"NANA: Ch {novel_chapter_number} - De-duplication removed {removed_char_count} characters. Text marked as potentially flawed for KG."
+                f"NANA: Ch {novel_chapter_number} - Post-draft cleaning modified the text (duplicates removed: {removed_char_count}, gpt-isms replaced: {replaced})."
             )
-            current_text_to_process = deduplicated_text
+            current_text_to_process = cleaned_text
             await self._save_debug_output(
                 novel_chapter_number,
                 "deduplicated_text_after_draft",
@@ -709,7 +747,7 @@ class NANA_Orchestrator:
             )
         else:
             logger.info(
-                f"NANA: Ch {novel_chapter_number} - Post-draft de-duplication found no significant changes."
+                f"NANA: Ch {novel_chapter_number} - Post-draft de-duplication and cleanup found no significant changes."
             )
 
         revisions_made = 0
@@ -854,11 +892,14 @@ class NANA_Orchestrator:
         dedup_text_after_rev, removed_after_rev = await self.perform_deduplication(
             current_text_to_process, novel_chapter_number
         )
-        if removed_after_rev > 0:
+        cleaned_after_rev, replaced_after_rev = await self.perform_gptism_cleanup(
+            dedup_text_after_rev, novel_chapter_number
+        )
+        if removed_after_rev > 0 or replaced_after_rev > 0:
             logger.info(
-                f"NANA: Ch {novel_chapter_number} - De-duplication after revisions removed {removed_after_rev} characters."
+                f"NANA: Ch {novel_chapter_number} - Post-revision cleaning modified the text (duplicates removed: {removed_after_rev}, gpt-isms replaced: {replaced_after_rev})."
             )
-            current_text_to_process = dedup_text_after_rev
+            current_text_to_process = cleaned_after_rev
             is_from_flawed_source_for_kg = True
             await self._save_debug_output(
                 novel_chapter_number,

--- a/processing/gptism_cleanup.py
+++ b/processing/gptism_cleanup.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import logging
+import random
+from typing import Dict, List, Tuple
+
+from rapidfuzz import fuzz
+
+import utils
+
+logger = logging.getLogger(__name__)
+
+# Common phrases often produced by language models and replacement options
+GPT_ISM_PATTERNS: Dict[str, List[str]] = {
+    "as an ai language model": [
+        "from a broader perspective",
+        "considering the context",
+    ],
+    "i'm sorry": [
+        "unfortunately",
+        "regrettably",
+    ],
+    "i do not have personal opinions": [
+        "sources differ on this",
+        "there is no clear consensus",
+    ],
+}
+
+DEFAULT_SIMILARITY_THRESHOLD = 80.0
+
+
+def replace_gptisms(
+    text: str, threshold: float = DEFAULT_SIMILARITY_THRESHOLD
+) -> Tuple[str, int]:
+    """Replace common GPT-isms in ``text`` with alternative phrasings."""
+    utils.load_spacy_model_if_needed()
+    nlp = utils.spacy_manager.nlp
+    if nlp is None or not text.strip():
+        return text, 0
+
+    replacements = 0
+    new_sentences: List[str] = []
+    for sent in nlp(text).sents:
+        sent_text = sent.text
+        best_phrase = None
+        best_score = 0
+        for phrase in GPT_ISM_PATTERNS:
+            score = fuzz.partial_ratio(sent_text.lower(), phrase)
+            if score > best_score:
+                best_score = score
+                best_phrase = phrase
+        if best_phrase and best_score >= threshold:
+            options = GPT_ISM_PATTERNS[best_phrase]
+            replacement = random.choice(options)
+            logger.info(
+                "Replacing GPT-ism '%s' (score %.1f) with '%s'",
+                best_phrase,
+                best_score,
+                replacement,
+            )
+            sent_text = replacement
+            replacements += 1
+        new_sentences.append(sent_text.strip())
+    cleaned_text = " ".join(new_sentences)
+    return cleaned_text, replacements

--- a/tests/test_gptism_cleanup.py
+++ b/tests/test_gptism_cleanup.py
@@ -1,0 +1,24 @@
+import spacy
+
+import utils
+from processing.gptism_cleanup import replace_gptisms
+
+
+def test_replace_gptisms_no_model(monkeypatch):
+    monkeypatch.setattr(utils.spacy_manager, "_nlp", None)
+    monkeypatch.setattr(utils, "load_spacy_model_if_needed", lambda: None)
+    text = "As an AI language model, I cannot help with that."
+    cleaned, count = replace_gptisms(text, threshold=80)
+    assert cleaned == text
+    assert count == 0
+
+
+def test_replace_gptisms_with_model(monkeypatch):
+    nlp = spacy.blank("en")
+    nlp.add_pipe("sentencizer")
+    monkeypatch.setattr(utils.spacy_manager, "_nlp", nlp)
+    monkeypatch.setattr(utils, "load_spacy_model_if_needed", lambda: None)
+    text = "As an AI language model, I cannot help with that."
+    cleaned, count = replace_gptisms(text, threshold=80)
+    assert count == 1
+    assert "as an ai language model" not in cleaned.lower()


### PR DESCRIPTION
## Summary
- add `processing.gptism_cleanup` for removing common LLM phrases
- expose `ENABLE_GPTISM_CLEANUP` and `GPTISM_SIMILARITY_THRESHOLD` in `config.py`
- clean up text in `NANA_Orchestrator` before and after revisions
- test GPT-ism cleanup logic
- document new feature and config options

## Testing
- `ruff check . --select I --fix`
- `ruff format .`
- `ruff check .`
- `ruff format --check .`
- `pytest tests/ -v --cov=. --cov-report=term-missing`
- `mypy .` *(fails: Library stubs not installed for "yaml" and many missing attribute errors)*

------
https://chatgpt.com/codex/tasks/task_e_6858e6e9d058832f89471e3c53479870