### PR TITLE
Centralize KG property keys

### DIFF
--- a/data_access/character_queries.py
+++ b/data_access/character_queries.py
@@ -7,6 +7,7 @@ from neo4j.exceptions import ServiceUnavailable  # type: ignore
 
 import config
 import utils
+from utils import kg_property_keys as kg_keys
 from core.db_manager import neo4j_manager
 from kg_constants import KG_IS_PROVISIONAL, KG_NODE_CHAPTER_UPDATED
 from kg_maintainer.models import CharacterProfile
@@ -192,7 +193,7 @@ async def sync_full_state_from_object_to_db(profiles_data: Dict[str, Any]) -> bo
 
         for key, value_str in profile_dict.items():
             if (
-                key.startswith("development_in_chapter_")
+                key.startswith(kg_keys.DEVELOPMENT_PREFIX)
                 and isinstance(value_str, str)
                 and value_str.strip()
             ):
@@ -212,7 +213,7 @@ async def sync_full_state_from_object_to_db(profiles_data: Dict[str, Any]) -> bo
                         "summary": dev_event_summary,
                         KG_NODE_CHAPTER_UPDATED: chap_num_int,
                         KG_IS_PROVISIONAL: profile_dict.get(
-                            f"source_quality_chapter_{chap_num_int}"
+                            kg_keys.source_quality_key(chap_num_int)
                         )
                         == "provisional_from_unrevised_draft",
                     }
@@ -293,7 +294,7 @@ async def sync_full_state_from_object_to_db(profiles_data: Dict[str, Any]) -> bo
                             rel_cypher_props[k_rel] = v_rel
 
                 rel_cypher_props[KG_IS_PROVISIONAL] = (
-                    profile_dict.get(f"source_quality_chapter_{chapter_added_val}")
+                    profile_dict.get(kg_keys.source_quality_key(chapter_added_val))
                     == "provisional_from_unrevised_draft"
                 )
 
@@ -418,10 +419,10 @@ async def get_character_profile_by_name(name: str) -> Optional[CharacterProfile]
             chapter_num = dev_rec.get("chapter")
             summary = dev_rec.get("summary")
             if chapter_num is not None and summary is not None:
-                dev_key = f"development_in_chapter_{chapter_num}"
+                dev_key = kg_keys.development_key(chapter_num)
                 profile[dev_key] = summary
                 if dev_rec.get(KG_IS_PROVISIONAL):
-                    profile[f"source_quality_chapter_{chapter_num}"] = (
+                    profile[kg_keys.source_quality_key(chapter_num)] = (
                         "provisional_from_unrevised_draft"
                     )
 
@@ -524,10 +525,10 @@ async def get_character_profiles_from_db() -> Dict[str, CharacterProfile]:
                 chapter_num = dev_rec.get("chapter")
                 summary = dev_rec.get("summary")
                 if chapter_num is not None and summary is not None:
-                    dev_key = f"development_in_chapter_{chapter_num}"
+                    dev_key = kg_keys.development_key(chapter_num)
                     profile[dev_key] = summary
                     if dev_rec.get(KG_IS_PROVISIONAL):
-                        profile[f"source_quality_chapter_{chapter_num}"] = (
+                        profile[kg_keys.source_quality_key(chapter_num)] = (
                             "provisional_from_unrevised_draft"
                         )
 

--- a/data_access/cypher_builders/world_cypher.py
+++ b/data_access/cypher_builders/world_cypher.py
@@ -3,6 +3,7 @@ import logging
 from typing import Any, Dict, List, Tuple
 
 import config
+from utils import kg_property_keys as kg_keys
 from kg_constants import (
     KG_IS_PROVISIONAL,
     KG_NODE_CREATED_CHAPTER,
@@ -26,8 +27,8 @@ def generate_world_element_node_cypher(
     }
     node_props["is_deleted"] = False
 
-    current_chapter_source_quality_key = (
-        f"source_quality_chapter_{chapter_number_for_delta}"
+    current_chapter_source_quality_key = kg_keys.source_quality_key(
+        chapter_number_for_delta
     )
     if (
         isinstance(item.properties, dict)
@@ -43,9 +44,9 @@ def generate_world_element_node_cypher(
             if (
                 isinstance(value, (str, int, float, bool))
                 and key not in node_props
-                and not key.startswith("elaboration_in_chapter_")
-                and not key.startswith("source_quality_chapter_")
-                and not key.startswith("added_in_chapter_")
+                and not key.startswith(kg_keys.ELABORATION_PREFIX)
+                and not key.startswith(kg_keys.SOURCE_QUALITY_PREFIX)
+                and not key.startswith(kg_keys.ADDED_PREFIX)
                 and key not in ["goals", "rules", "key_elements", "traits"]
             ):
                 node_props[key] = value
@@ -132,7 +133,7 @@ def generate_world_element_node_cypher(
                             )
                         )
 
-    elab_event_key = f"elaboration_in_chapter_{chapter_number_for_delta}"
+    elab_event_key = kg_keys.elaboration_key(chapter_number_for_delta)
     if isinstance(item.properties, dict) and elab_event_key in item.properties:
         elab_summary = item.properties[elab_event_key]
         if isinstance(elab_summary, str) and elab_summary.strip():

--- a/kg_maintainer/parsing.py
+++ b/kg_maintainer/parsing.py
@@ -4,6 +4,7 @@ import logging  # Added logging
 from typing import Any, Dict, List  # Added Any, List
 
 import utils
+from utils import kg_property_keys as kg_keys
 
 from .models import CharacterProfile, WorldItem
 
@@ -191,7 +192,7 @@ def parse_unified_character_updates(
         else:  # Ensure it's always a dict
             processed_char_attributes["relationships"] = {}
 
-        dev_key_standard = f"development_in_chapter_{chapter_number}"
+        dev_key_standard = kg_keys.development_key(chapter_number)
         # If LLM includes this key (even with different casing/spacing), it will be normalized by _normalize_attributes
         # if dev_key_standard is in CHAR_UPDATE_KEY_MAP. For now, handle it explicitly.
         specific_dev_key_from_llm = next(
@@ -269,7 +270,7 @@ def parse_unified_world_updates(
         # The WorldItem model itself might normalize this for ID generation.
 
         category_dict_by_item_name: Dict[str, WorldItem] = {}
-        elaboration_key_standard = f"elaboration_in_chapter_{chapter_number}"
+        elaboration_key_standard = kg_keys.elaboration_key(chapter_number)
 
         if (
             category_name_llm.lower() == "overview"

--- a/models/kg_models.py
+++ b/models/kg_models.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional
 from pydantic import BaseModel, Field
 
 import utils
+from utils import kg_property_keys as kg_keys
 from kg_constants import KG_IS_PROVISIONAL, KG_NODE_CREATED_CHAPTER
 
 
@@ -44,7 +45,7 @@ class CharacterProfile(BaseModel):
         """Return development notes up to a chapter number."""
 
         notes: List[str] = []
-        prefix = "development_in_chapter_"
+        prefix = kg_keys.DEVELOPMENT_PREFIX
         for key, val in sorted(self.updates.items()):
             if not key.startswith(prefix):
                 continue
@@ -120,7 +121,7 @@ class WorldItem(BaseModel):
         """Return elaboration notes up to a chapter number."""
 
         notes: List[str] = []
-        prefix = "elaboration_in_chapter_"
+        prefix = kg_keys.ELABORATION_PREFIX
         for key, val in sorted(self.properties.items()):
             if not key.startswith(prefix):
                 continue

--- a/prompt_data_getters.py
+++ b/prompt_data_getters.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List, Optional, Set
 
 import config
 import utils  # For _is_fill_in
+from utils import kg_property_keys as kg_keys
 
 # from state_manager import state_manager # No longer directly used
 from data_access import character_queries, kg_queries, world_queries  # MODIFIED
@@ -107,7 +108,7 @@ async def get_character_state_snippet_for_prompt(
                 [
                     k
                     for k in profile_fallback
-                    if k.startswith("development_in_chapter_")
+                    if k.startswith(kg_keys.DEVELOPMENT_PREFIX)
                     and int(k.split("_")[-1]) <= effective_filter_chapter
                 ],
                 key=lambda x: int(x.split("_")[-1]),
@@ -155,7 +156,7 @@ async def get_character_state_snippet_for_prompt(
                 [
                     k
                     for k in profile_fallback
-                    if k.startswith("development_in_chapter_")
+                    if k.startswith(kg_keys.DEVELOPMENT_PREFIX)
                     and int(k.split("_")[-1]) <= effective_filter_chapter
                 ],
                 key=lambda x: int(x.split("_")[-1]),
@@ -271,7 +272,7 @@ async def get_world_state_snippet_for_prompt(
                 if item_count_fb >= world_categories_to_fetch[category_name_result]:
                     break
                 if item_name_fb.startswith(
-                    ("_", "source_quality_chapter_", "category_updated_in_chapter_")
+                    ("_", kg_keys.SOURCE_QUALITY_PREFIX, "category_updated_in_chapter_")
                 ):
                     continue
                 desc_snip_fb = ""
@@ -369,7 +370,11 @@ def _format_dict_for_plain_text_prompt(
         value = data[key]
 
         if key.startswith(
-            ("source_quality_chapter_", "updated_in_chapter_", "added_in_chapter_")
+            (
+                kg_keys.SOURCE_QUALITY_PREFIX,
+                kg_keys.UPDATED_PREFIX,
+                kg_keys.ADDED_PREFIX,
+            )
         ) and key not in ["prompt_notes"]:
             continue
         if key == "is_provisional_hint":
@@ -425,9 +430,9 @@ def _add_provisional_notes_and_filter_developments(
     )
 
     dev_elaboration_prefix = (
-        "development_in_chapter_" if is_character else "elaboration_in_chapter_"
+        kg_keys.DEVELOPMENT_PREFIX if is_character else kg_keys.ELABORATION_PREFIX
     )
-    added_prefix = "added_in_chapter_"
+    added_prefix = kg_keys.ADDED_PREFIX
 
     keys_to_remove = []
     has_provisional_data_relevant_to_filter = False
@@ -451,7 +456,7 @@ def _add_provisional_notes_and_filter_developments(
                     f"Could not parse chapter from key '{key}' during filtering: {e}"
                 )
 
-        if key.startswith("source_quality_chapter_"):
+        if key.startswith(kg_keys.SOURCE_QUALITY_PREFIX):
             try:
                 chap_num_of_source_str = key.split("_")[-1]
                 chap_num_of_source = (

--- a/tests/test_kg_property_keys.py
+++ b/tests/test_kg_property_keys.py
@@ -1,0 +1,15 @@
+from utils import kg_property_keys as keys
+
+
+def test_key_generation():
+    assert keys.elaboration_key(2) == "elaboration_in_chapter_2"
+    assert keys.development_key(3) == "development_in_chapter_3"
+    assert keys.source_quality_key(1) == "source_quality_chapter_1"
+    assert keys.added_key(5) == "added_in_chapter_5"
+    assert keys.updated_key(6) == "updated_in_chapter_6"
+
+
+def test_parse_elaboration_key():
+    assert keys.parse_elaboration_key("elaboration_in_chapter_7") == 7
+    assert keys.parse_elaboration_key("elaboration_in_chapter_bad") is None
+    assert keys.parse_elaboration_key("other_key") is None

--- a/utils/kg_property_keys.py
+++ b/utils/kg_property_keys.py
@@ -1,0 +1,43 @@
+"""Utilities for constructing and parsing chapter-based KG property keys."""
+
+from typing import Optional
+
+ELABORATION_PREFIX = "elaboration_in_chapter_"
+DEVELOPMENT_PREFIX = "development_in_chapter_"
+SOURCE_QUALITY_PREFIX = "source_quality_chapter_"
+ADDED_PREFIX = "added_in_chapter_"
+UPDATED_PREFIX = "updated_in_chapter_"
+
+
+def elaboration_key(chapter: int) -> str:
+    """Return the elaboration key for ``chapter``."""
+    return f"{ELABORATION_PREFIX}{chapter}"
+
+
+def development_key(chapter: int) -> str:
+    """Return the development key for ``chapter``."""
+    return f"{DEVELOPMENT_PREFIX}{chapter}"
+
+
+def source_quality_key(chapter: int) -> str:
+    """Return the source quality key for ``chapter``."""
+    return f"{SOURCE_QUALITY_PREFIX}{chapter}"
+
+
+def added_key(chapter: int) -> str:
+    """Return the added key for ``chapter``."""
+    return f"{ADDED_PREFIX}{chapter}"
+
+
+def updated_key(chapter: int) -> str:
+    """Return the updated key for ``chapter``."""
+    return f"{UPDATED_PREFIX}{chapter}"
+
+
+def parse_elaboration_key(key: str) -> Optional[int]:
+    """Return the chapter from an elaboration key if parsable."""
+    if key.startswith(ELABORATION_PREFIX):
+        suffix = key[len(ELABORATION_PREFIX) :]
+        if suffix.isdigit():
+            return int(suffix)
+    return None


### PR DESCRIPTION
## Summary
- implement `utils/kg_property_keys` for knowledge graph property key helpers
- refactor world and character modules to use helper functions
- update cypher builders and parsing/merge logic
- adjust prompt utilities to rely on centralized key constants
- add unit tests for key generation and parsing

## Testing
- `ruff check . && ruff format --check .`
- `pytest tests/ -v --cov=. --cov-report=term-missing`
- `mypy .` *(fails: Library stubs not installed for "yaml" and other missing attributes)*

------
https://chatgpt.com/codex/tasks/task_e_68597f34b240832f873af2c3691fc633