### PR TITLE
Add concurrent evaluation stage

### DIFF
--- a/orchestration/chapter_flow.py
+++ b/orchestration/chapter_flow.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional
+import asyncio
 
 if TYPE_CHECKING:  # pragma: no cover - type hint import
     from .nana_orchestrator import NANA_Orchestrator
@@ -14,12 +15,11 @@ async def run_chapter_pipeline(
         chapter_num=novel_chapter_number, step="Starting Chapter"
     )
 
-    if not await orchestrator._validate_plot_outline(novel_chapter_number):
+    validate_task = orchestrator._validate_plot_outline(novel_chapter_number)
+    prereq_task = orchestrator._prepare_chapter_prerequisites(novel_chapter_number)
+    valid, prereq_result = await asyncio.gather(validate_task, prereq_task)
+    if not valid:
         return None
-
-    prereq_result = await orchestrator._prepare_chapter_prerequisites(
-        novel_chapter_number
-    )
     processed_prereqs = await orchestrator._process_prereq_result(
         novel_chapter_number, prereq_result
     )

--- a/orchestration/nana_orchestrator.py
+++ b/orchestration/nana_orchestrator.py
@@ -425,9 +425,11 @@ class NANA_Orchestrator:
         plot_point_index: int,
         hybrid_context_for_draft: str,
         patched_spans: List[Tuple[int, int]],
+        run_kg_extraction: bool = False,
     ) -> Tuple[
         EvaluationResult,
         List[ProblemDetail],
+        Optional[Dict[str, int]],
         Optional[Dict[str, int]],
         Optional[Dict[str, int]],
     ]:
@@ -471,6 +473,23 @@ class NANA_Orchestrator:
             )
             task_names.append("continuity")
 
+        kg_usage: Optional[Dict[str, int]] = None
+        if run_kg_extraction:
+            char_profiles, world_building = await asyncio.gather(
+                character_queries.get_character_profiles_from_db(),
+                world_queries.get_world_building_from_db(),
+            )
+            tasks_to_run.append(
+                self.kg_maintainer_agent.extract_and_merge_knowledge(
+                    self.plot_outline,
+                    char_profiles,
+                    world_building,
+                    novel_chapter_number,
+                    current_text,
+                )
+            )
+            task_names.append("kg")
+
         results = await asyncio.gather(*tasks_to_run)
 
         eval_result_obj = None
@@ -484,7 +503,9 @@ class NANA_Orchestrator:
             result_idx += 1
         if "continuity" in task_names:
             continuity_problems, continuity_usage = results[result_idx]
-
+            result_idx += 1
+        if "kg" in task_names:
+            kg_usage = results[result_idx]
         if eval_result_obj is None:
             eval_result_obj = {
                 "needs_revision": False,
@@ -497,7 +518,13 @@ class NANA_Orchestrator:
                 "narrative_depth_issues": None,
             }
 
-        return eval_result_obj, continuity_problems, eval_usage, continuity_usage
+        return (
+            eval_result_obj,
+            continuity_problems,
+            eval_usage,
+            continuity_usage,
+            kg_usage,
+        )
 
     async def _perform_revisions(
         self,
@@ -766,6 +793,7 @@ class NANA_Orchestrator:
                 continuity_problems,
                 eval_usage,
                 continuity_usage,
+                kg_usage,
             ) = await self._run_evaluation_cycle(
                 novel_chapter_number,
                 attempt,
@@ -774,6 +802,7 @@ class NANA_Orchestrator:
                 plot_point_index,
                 hybrid_context_for_draft,
                 patched_spans,
+                run_kg_extraction=(attempt == 1),
             )
 
             self._accumulate_tokens(
@@ -784,6 +813,11 @@ class NANA_Orchestrator:
                 f"Ch{novel_chapter_number}-ContinuityCheck-Attempt{attempt}",
                 continuity_usage,
             )
+            if kg_usage is not None:
+                self._accumulate_tokens(
+                    f"Ch{novel_chapter_number}-KGExtraction-Attempt{attempt}",
+                    kg_usage,
+                )
 
             evaluation_result: EvaluationResult = eval_result_obj
             await self._save_debug_output(

--- a/processing/gptism_cleanup.py
+++ b/processing/gptism_cleanup.py
@@ -15,6 +15,10 @@ logger = logging.getLogger(__name__)
 # The goal is not to eliminate these phrases entirely, but to provide SAGA
 # with a library of alternatives to prevent robotic repetition.
 GPT_ISM_PATTERNS: Dict[str, List[str]] = {
+    "as an ai language model": [
+        "from a broader perspective",
+        "considering the context",
+    ],
     # --- I. Transitional & Scene-Setting Phrases ---
     # These are often used to start paragraphs or set a mood.
     "in the silence that followed": [
@@ -41,7 +45,6 @@ GPT_ISM_PATTERNS: Dict[str, List[str]] = {
         "at the epicenter of the decay",
         "in the very core of the ruins",
     ],
-
     # --- II. Emotional & Internal State Descriptors ---
     # LLMs often describe emotions in an abstract or cliché way.
     "a sense of [emotion] washed over [character]": [
@@ -83,7 +86,6 @@ GPT_ISM_PATTERNS: Dict[str, List[str]] = {
         "an anomaly registered in its emotional subroutines",
         "its primary directive warred with an emergent protocol",
     ],
-
     # --- III. Character Actions & Movements ---
     # These are common physical actions that become repetitive.
     "[character] tilted their head": [
@@ -110,7 +112,6 @@ GPT_ISM_PATTERNS: Dict[str, List[str]] = {
         "[They] inclined their head in agreement",
         "[Character] conceded the point with a slight dip of their chin",
     ],
-
     # --- IV. Descriptive & Intensifying Phrases ("Fluff") ---
     # These phrases often weaken prose or state the obvious.
     "the world seemed to hold its breath": [
@@ -132,7 +133,6 @@ GPT_ISM_PATTERNS: Dict[str, List[str]] = {
         # Another filler phrase that weakens the statement it follows.
         "[Replacement suggestions: This phrase is often unnecessary. Consider deleting it to make the preceding statement stronger.]",
     ],
-
     # --- V. Concluding & Thematic Statements ---
     # LLMs have a tendency to explicitly summarize themes.
     "in the end, it was all about...": [


### PR DESCRIPTION
## Summary
- concurrently validate plot and prerequisites
- allow KG extraction alongside evaluation & continuity checks
- handle KG token tracking
- restore `as an ai language model` GPT-ism for tests

## Testing
- `ruff check . && ruff format --check .`
- `pytest tests/ -v --cov=. --cov-report=term-missing`
- `mypy .` *(fails: Library stubs not installed for "yaml" and other missing attributes)*

------
https://chatgpt.com/codex/tasks/task_e_6859ccda8780832fa21285a4ccf8da66