### PR TITLE
Add key parsing helpers and refactor usage

### DIFF
--- a/data_access/character_queries.py
+++ b/data_access/character_queries.py
@@ -7,10 +7,10 @@ from neo4j.exceptions import ServiceUnavailable  # type: ignore
 
 import config
 import utils
-from utils import kg_property_keys as kg_keys
 from core.db_manager import neo4j_manager
 from kg_constants import KG_IS_PROVISIONAL, KG_NODE_CHAPTER_UPDATED
 from kg_maintainer.models import CharacterProfile
+from utils import kg_property_keys as kg_keys
 
 from .cypher_builders.character_cypher import (
     TRAIT_NAME_TO_CANONICAL,
@@ -198,11 +198,8 @@ async def sync_full_state_from_object_to_db(profiles_data: Dict[str, Any]) -> bo
                 and value_str.strip()
             ):
                 try:
-                    chap_num_int_str = key.split("_")[-1]
-                    chap_num_int = (
-                        int(chap_num_int_str) if chap_num_int_str.isdigit() else -1
-                    )
-                    if chap_num_int == -1:
+                    chap_num_int = kg_keys.parse_development_key(key)
+                    if chap_num_int is None:
                         continue
 
                     dev_event_summary = value_str.strip()

--- a/data_access/world_queries.py
+++ b/data_access/world_queries.py
@@ -390,11 +390,8 @@ async def sync_full_state_from_object_to_db(world_data: Dict[str, Any]) -> bool:
                     and value_val.strip()
                 ):
                     try:
-                        chap_num_val_str = key_str.split("_")[-1]
-                        chap_num_val = (
-                            int(chap_num_val_str) if chap_num_val_str.isdigit() else -1
-                        )
-                        if chap_num_val == -1:
+                        chap_num_val = kg_keys.parse_elaboration_key(key_str)
+                        if chap_num_val is None:
                             logger.warning(
                                 f"Could not parse chapter number from world elab key: {key_str} for item {item_name_str}"
                             )

--- a/models/kg_models.py
+++ b/models/kg_models.py
@@ -7,8 +7,8 @@ from typing import Any, Dict, List, Optional
 from pydantic import BaseModel, Field
 
 import utils
-from utils import kg_property_keys as kg_keys
 from kg_constants import KG_IS_PROVISIONAL, KG_NODE_CREATED_CHAPTER
+from utils import kg_property_keys as kg_keys
 
 
 class CharacterProfile(BaseModel):
@@ -49,9 +49,8 @@ class CharacterProfile(BaseModel):
         for key, val in sorted(self.updates.items()):
             if not key.startswith(prefix):
                 continue
-            try:
-                chap = int(key.split("_")[-1])
-            except (ValueError, IndexError):
+            chap = kg_keys.parse_development_key(key)
+            if chap is None:
                 continue
             if up_to_chapter is None or chap <= up_to_chapter:
                 if isinstance(val, str):
@@ -125,9 +124,8 @@ class WorldItem(BaseModel):
         for key, val in sorted(self.properties.items()):
             if not key.startswith(prefix):
                 continue
-            try:
-                chap = int(key.split("_")[-1])
-            except (ValueError, IndexError):
+            chap = kg_keys.parse_elaboration_key(key)
+            if chap is None:
                 continue
             if up_to_chapter is None or chap <= up_to_chapter:
                 if isinstance(val, str):

--- a/orchestration/nana_orchestrator.py
+++ b/orchestration/nana_orchestrator.py
@@ -447,6 +447,8 @@ class NANA_Orchestrator:
 
         # ignore_spans = patched_spans if attempt == 1 else None
 
+        ignore_spans = patched_spans if attempt == 1 else None
+
         if config.ENABLE_COMPREHENSIVE_EVALUATION:
             tasks_to_run.append(
                 self.evaluator_agent.evaluate_chapter_draft(
@@ -458,7 +460,7 @@ class NANA_Orchestrator:
                     plot_point_focus,
                     plot_point_index,
                     hybrid_context_for_draft,
-                    ignore_spans=patched_spans,
+                    ignore_spans=ignore_spans,
                 )
             )
             task_names.append("evaluation")
@@ -470,7 +472,7 @@ class NANA_Orchestrator:
                     current_text,
                     novel_chapter_number,
                     hybrid_context_for_draft,
-                    ignore_spans=patched_spans,
+                    ignore_spans=ignore_spans,
                 )
             )
             task_names.append("continuity")

--- a/tests/test_kg_property_keys.py
+++ b/tests/test_kg_property_keys.py
@@ -13,3 +13,14 @@ def test_parse_elaboration_key():
     assert keys.parse_elaboration_key("elaboration_in_chapter_7") == 7
     assert keys.parse_elaboration_key("elaboration_in_chapter_bad") is None
     assert keys.parse_elaboration_key("other_key") is None
+
+
+def test_parse_other_keys():
+    assert keys.parse_development_key("development_in_chapter_2") == 2
+    assert keys.parse_development_key("development_in_chapter_x") is None
+    assert keys.parse_source_quality_key("source_quality_chapter_3") == 3
+    assert keys.parse_source_quality_key("source_quality_chapter_bad") is None
+    assert keys.parse_added_key("added_in_chapter_4") == 4
+    assert keys.parse_added_key("added_in_chapter_") is None
+    assert keys.parse_updated_key("updated_in_chapter_5") == 5
+    assert keys.parse_updated_key("updated_in_chapter_bad") is None

--- a/utils/kg_property_keys.py
+++ b/utils/kg_property_keys.py
@@ -41,3 +41,39 @@ def parse_elaboration_key(key: str) -> Optional[int]:
         if suffix.isdigit():
             return int(suffix)
     return None
+
+
+def parse_development_key(key: str) -> Optional[int]:
+    """Return the chapter from a development key if parsable."""
+    if key.startswith(DEVELOPMENT_PREFIX):
+        suffix = key[len(DEVELOPMENT_PREFIX) :]
+        if suffix.isdigit():
+            return int(suffix)
+    return None
+
+
+def parse_source_quality_key(key: str) -> Optional[int]:
+    """Return the chapter from a source quality key if parsable."""
+    if key.startswith(SOURCE_QUALITY_PREFIX):
+        suffix = key[len(SOURCE_QUALITY_PREFIX) :]
+        if suffix.isdigit():
+            return int(suffix)
+    return None
+
+
+def parse_added_key(key: str) -> Optional[int]:
+    """Return the chapter from an added key if parsable."""
+    if key.startswith(ADDED_PREFIX):
+        suffix = key[len(ADDED_PREFIX) :]
+        if suffix.isdigit():
+            return int(suffix)
+    return None
+
+
+def parse_updated_key(key: str) -> Optional[int]:
+    """Return the chapter from an updated key if parsable."""
+    if key.startswith(UPDATED_PREFIX):
+        suffix = key[len(UPDATED_PREFIX) :]
+        if suffix.isdigit():
+            return int(suffix)
+    return None


### PR DESCRIPTION
## Summary
- add `parse_*` helpers for KG property keys
- refactor property parsing to use helpers
- adjust evaluation cycle logic for `ignore_spans`
- format `gptism_cleanup.py` to satisfy linters
- extend `test_kg_property_keys` with new helper tests

## Testing
- `ruff check .`
- `ruff format --check .`
- `pytest tests/ -v --cov=. --cov-report=term-missing`
- `mypy .` *(fails: library stubs not installed and various attribute errors)*

------
https://chatgpt.com/codex/tasks/task_e_685a15d5be34832f9540d8f2cd048317