### PR TITLE
Refine LLM prompts

### DIFF
--- a/agents/kg_maintainer_agent.py
+++ b/agents/kg_maintainer_agent.py
@@ -64,7 +64,7 @@ async def _llm_summarize_full_chapter_text(
 
 # Prompt template for entity resolution, embedded to avoid new file dependency
 ENTITY_RESOLUTION_PROMPT_TEMPLATE = """/no_think
-You are an expert knowledge graph analyst for a creative writing project. Your task is to determine if two entities from the narrative's knowledge graph are referring to the same canonical thing based on their names, properties, and relationships.
+You are an expert knowledge graph analyst for a creative writing project. Determine if two entities from the narrative's knowledge graph refer to the same canonical thing based on their names, properties, and relationships.
 
 **Entity 1 Details:**
 - Name: {{ entity1.name }}
@@ -98,7 +98,7 @@ You are an expert knowledge graph analyst for a creative writing project. Your t
 Based on all the provided context, including name similarity, properties (like descriptions), and shared relationships, are "Entity 1" and "Entity 2" the same entity within the story's canon? For example, "The Locket" and "The Pendant" might be the same item, or "The Shattered Veil" and "Shattered Veil" are likely the same faction.
 
 **Response Format:**
-Respond in JSON format only, with no other text, commentary, or markdown. Your entire response must be a single, valid JSON object with the following structure:
+Output only JSON, with no other text or markdown. Your entire response must be a single, valid JSON object with the following structure:
 {
   "is_same_entity": boolean,
   "confidence_score": float (from 0.0 to 1.0, representing your certainty),
@@ -109,7 +109,7 @@ Respond in JSON format only, with no other text, commentary, or markdown. Your e
 # Prompt template for dynamic relationship resolution
 DYNAMIC_REL_RESOLUTION_PROMPT_TEMPLATE = """/no_think
 You analyze a relationship from the novel's knowledge graph and provide a
-single, canonical predicate name in ALL_CAPS_WITH_UNDERSCORES describing the
+single canonical predicate name in ALL_CAPS_WITH_UNDERSCORES describing the
 relationship between the subject and object.
 
 Subject: {{ subject }} ({{ subject_labels }})
@@ -118,7 +118,7 @@ Existing Type: {{ type }}
 Subject Description: {{ subject_desc }}
 Object Description: {{ object_desc }}
 
-Respond with only the predicate string, no extra words.
+Respond with only the predicate string, nothing else.
 """
 
 

--- a/processing/revision_logic.py
+++ b/processing/revision_logic.py
@@ -291,13 +291,13 @@ async def _generate_single_patch_instruction_llm(
     )
 
     few_shot_patch_example_str = """
---- Example of how to provide 'replace_with' text (**Ignore the narrative details in this example.**) ---
+--- Example of how to provide `replace_with` text (content is illustrative only) ---
 IF THE PROBLEM WAS:
   - Issue Category: narrative_depth
   - Problem Description: The reaction of Elara to seeing the ghost felt understated.
   - Original Quote Illustrating Problem: "Elara saw the ghost and gasped."
   - Suggested Fix Focus: Expand on Elara's internal emotional reaction and physical response.
-THEN YOUR 'replace_with' TEXT MIGHT BE (just the text, no other explanation):
+  A suitable `replace_with` text might look like this (just the text, no extra explanation):
 A chill traced Elara's spine, not from the crypt's cold, but from the translucent figure coalescing before her. Her breath hitched, a silent scream trapped in her throat as the ghostly visage turned its empty sockets towards her. Every instinct screamed to flee, but her feet felt rooted to the stone floor, a terrifying paralysis gripping her.
 --- End of Example ---
 """

--- a/prompts/bootstrapper/fill_character_field.j2
+++ b/prompts/bootstrapper/fill_character_field.j2
@@ -1,12 +1,12 @@
 /no_think
 You are a character development expert.
-Your task is to generate a single, compelling value for a specific field in a character's profile, based on the provided context.
+Your task is to produce a single, compelling value for a specific field in a character's profile using the provided context.
 
 **Instructions:**
 1.  Analyze the provided `NOVEL CONTEXT` and `CHARACTER PROFILE`.
 2.  Generate a creative and fitting value for the field: `{{ field_name }}`.
-3.  Your output MUST be a single, valid JSON object with one key: `{{ field_name }}`.
-4.  Do NOT include any other text, commentary, or markdown.
+3.  Output a single, valid JSON object with one key: `{{ field_name }}`.
+4.  Do not include any other text or markdown.
 5.  If the context provides little information for this field, invent a reasonable detail consistent with the character's role and the novel's genre.
 
 ---

--- a/prompts/bootstrapper/fill_plot_field.j2
+++ b/prompts/bootstrapper/fill_plot_field.j2
@@ -1,12 +1,12 @@
 /no_think
 You are a creative assistant helping to bootstrap a novel concept.
-Your task is to generate a single, compelling value for a specific field in the novel's plot outline.
+Your task is to produce a single, engaging value for a specific field in the novel's plot outline.
 
 **Instructions:**
 1.  Analyze the provided `NOVEL CONTEXT`.
 2.  Generate a creative and fitting value for the field: `{{ field_name }}`.
-3.  Your output MUST be a single, valid JSON object with one key: `{{ field_name }}`.
-4.  Do NOT include any other text, commentary, or markdown.
+3.  Output a single, valid JSON object with one key: `{{ field_name }}`.
+4.  Do not include any other text or markdown.
 5.  If necessary context is missing, create a plausible value that fits the novel's genre and theme.
 
 ---

--- a/prompts/bootstrapper/fill_plot_points.j2
+++ b/prompts/bootstrapper/fill_plot_points.j2
@@ -1,13 +1,13 @@
 /no_think
 You are a master storyteller and plot architect.
-Your task is to generate a list of key plot points to complete a novel's narrative arc.
+Your task is to create a list of key plot points to complete the novel's narrative arc.
 
 **Instructions:**
 1.  Analyze the provided `NOVEL CONTEXT`.
 2.  Generate `{{ list_count }}` distinct, sequential, and compelling plot points that logically follow from the context.
 3.  Each plot point should be a concise sentence or two describing a major event or turning point in the story.
-4.  Your output MUST be a single, valid JSON object with one key: `plot_points`. The value must be a JSON array of strings.
-5.  Do NOT include any other text, commentary, or markdown.
+4.  Output a single, valid JSON object with one key: `plot_points`. The value must be a JSON array of strings.
+5.  Do not include any other text or markdown.
 6.  If the context leaves gaps, invent plot points that logically bridge the provided material.
 
 ---

--- a/prompts/bootstrapper/fill_world_item_field.j2
+++ b/prompts/bootstrapper/fill_world_item_field.j2
@@ -1,12 +1,12 @@
 /no_think
 You are a world-building expert.
-Your task is to generate a single, compelling value for a specific field in a world element's profile, based on the provided context.
+Your task is to produce a single, compelling value for a specific field in a world element's profile using the provided context.
 
 **Instructions:**
 1.  Analyze the provided `NOVEL CONTEXT` and `WORLD ITEM`.
 2.  Generate a creative and fitting value for the field: `{{ field_name }}`.
-3.  Your output MUST be a single, valid JSON object with one key: `{{ field_name }}`.
-4.  Do NOT include any other text, commentary, or markdown.
+3.  Output a single, valid JSON object with one key: `{{ field_name }}`.
+4.  Do not include any other text or markdown.
 5.  If details are sparse, craft a value that plausibly expands on the world item's role.
 
 ---

--- a/prompts/drafting_agent/draft_chapter_from_plot_point.j2
+++ b/prompts/drafting_agent/draft_chapter_from_plot_point.j2
@@ -22,6 +22,6 @@ You are an expert novelist tasked with writing the complete narrative text for a
 3.  Ensure your writing is consistent with the information provided in the "Hybrid Context" to maintain narrative flow and canonical accuracy.
 4.  Produce a rich, detailed narrative. Incorporate descriptive language, character introspection, dialogue, and action as appropriate for the genre and plot point.
 5.  The chapter should be substantial in length, aiming for at least {{ min_length }} characters of high-quality prose.
-6.  **Output ONLY the chapter text.** Do NOT include a "Chapter {{ chapter_number }}" header, a title, author commentary, or any other meta-discussion. Begin directly with the first sentence of the chapter.
+6.  **Output ONLY the chapter text.** Do not include a "Chapter {{ chapter_number }}" header, a title, author commentary, or any other meta discussion. Begin directly with the first sentence of the chapter.
 
 --- BEGIN CHAPTER {{ chapter_number }} TEXT ---

--- a/prompts/drafting_agent/draft_scene.j2
+++ b/prompts/drafting_agent/draft_scene.j2
@@ -22,7 +22,7 @@ You are an expert novelist tasked with writing a single scene.
 --- END PRIOR SCENES ---
 
 **Instructions:**
-1. Write the narrative prose for this scene only. Do not include headings or meta-commentary.
+1. Write the narrative prose for this scene only. Do not include headings or meta commentary.
 2. Ensure the prose aligns with the Hybrid Context and Prior Scene Prose.
 3. Aim for at least {{ min_length_per_scene }} characters of text.
 4. Output ONLY the scene text.

--- a/prompts/kg_maintainer_agent/chapter_summary.j2
+++ b/prompts/kg_maintainer_agent/chapter_summary.j2
@@ -1,5 +1,5 @@
 /no_think
-You are a concise summarizer. Summarize the key events, character developments, and plot advancements from the following Chapter {{ chapter_number }} text.
+You are a concise summarizer. Summarize the key events, character developments, and plot advancements from Chapter {{ chapter_number }}.
 The summary should be 1-3 sentences long and capture the most crucial information.
 Focus on what changed or was revealed.
 If the provided text is brief or ambiguous, summarize the most relevant details you can infer.
@@ -10,4 +10,4 @@ Full Chapter Text:
 --- END TEXT ---
 
 Output a single JSON object with the key `summary` containing the 1-3 sentence summary.
-No extra commentary.
+Do not include any commentary.

--- a/prompts/kg_maintainer_agent/enrich_character.j2
+++ b/prompts/kg_maintainer_agent/enrich_character.j2
@@ -1,5 +1,5 @@
 /no_think
-You are a knowledge graph enrichment expert for a creative writing project. You have been given the name of a character that has been identified as "thin" in the knowledge graph, meaning they were likely auto-created as a stub and are missing a core description.
+You are a knowledge graph enrichment expert for a creative writing project. You have been given the name of a character flagged as "thin" in the knowledge graph, meaning they were auto-created as a stub and lack a core description.
 
 Your task is to analyze the provided chapter context where this character appears and write a concise, canonical description for them.
 
@@ -23,7 +23,7 @@ No specific chapter context was found for this character. Base your description 
 **Instructions:**
 1. Based on the context, deduce the character's role, appearance, or key attributes.
 2. Write a single, concise, in-universe description for this character.
-3. Your response MUST be a single, valid JSON object with ONE key: "description". Do NOT include any other text, commentary, or markdown.
+3. Output a single, valid JSON object with one key: "description". Do not include any other text or markdown.
 
 **Ignore the narrative details in the below example. It shows the required format only.**
 **Example Response Format:**

--- a/prompts/kg_maintainer_agent/enrich_world_element.j2
+++ b/prompts/kg_maintainer_agent/enrich_world_element.j2
@@ -1,5 +1,5 @@
 /no_think
-You are a knowledge graph enrichment expert for a creative writing project. You have been given a world element that has been identified as "thin" in the knowledge graph, meaning it is missing a core description.
+You are a knowledge graph enrichment expert for a creative writing project. You have been given a world element flagged as "thin" in the knowledge graph, meaning it lacks a core description.
 
 Your task is to analyze the provided chapter context where this element appears and write a concise, canonical description for it.
 
@@ -25,7 +25,7 @@ No specific chapter context was found for this element. Base your description on
 **Instructions:**
 1. Based on the context, deduce the element's purpose, appearance, or key attributes.
 2. Write a single, concise, in-universe description for this world element.
-3. Your response MUST be a single, valid JSON object with ONE key: "description". Do NOT include any other text, commentary, or markdown.
+3. Output a single, valid JSON object with one key: "description". Do not include any other text or markdown.
 
 **Ignore the narrative details in the below example. It shows the required format only.**
 **Example Response Format:**

--- a/prompts/kg_maintainer_agent/extract_updates.j2
+++ b/prompts/kg_maintainer_agent/extract_updates.j2
@@ -1,7 +1,7 @@
 {% if no_think %}
 /no_think
 {% endif %}
-You are an expert knowledge graph extractor for a creative writing project. Your task is to analyze the provided chapter text and extract two types of information:
+You are an expert knowledge graph extractor for a creative writing project. Analyze the provided chapter text and extract two types of information:
 1.  **Character and World Updates:** Detailed updates for character profiles and world-building elements based on events in the chapter.
 2.  **Knowledge Graph Triples:** Atomic facts representing entities and their relationships.
 
@@ -16,10 +16,10 @@ You are an expert knowledge graph extractor for a creative writing project. Your
 
 **Instructions for Output:**
 - Your entire response MUST be a single, valid JSON object.
-- The JSON object must have three top-level keys: `character_updates`, `world_updates`, and `kg_triples`.
-- For `kg_triples`, provide a list of strings, where each string is a triple in the format: "SubjectEntityType:SubjectName | PREDICATE_IN_SNAKE_CASE | ObjectEntityType:ObjectName" or "SubjectEntityType:SubjectName | PREDICATE_IN_SNAKE_CASE | LiteralValue".
+- The JSON object must contain three top-level keys: `character_updates`, `world_updates`, and `kg_triples`.
+- For `kg_triples`, provide a list of strings where each string is a triple formatted as "SubjectEntityType:SubjectName | PREDICATE_IN_SNAKE_CASE | ObjectEntityType:ObjectName" or "SubjectEntityType:SubjectName | PREDICATE_IN_SNAKE_CASE | LiteralValue".
 - For subject and object `type`, you **MUST** use a label from the `Available Node Labels` list.
-- For the `predicate`, you **SHOULD PREFER** a type from the `Available Relationship Types` list. You may create a new, logical relationship type if absolutely necessary.
+- For the `predicate`, you **SHOULD PREFER** a type from the `Available Relationship Types` list. Create a new relationship type only if absolutely necessary.
 
 ---
 **Chapter {{ chapter_number }} Text to Analyze:**

--- a/prompts/patch_validation_agent/validate_patch.j2
+++ b/prompts/patch_validation_agent/validate_patch.j2
@@ -10,4 +10,4 @@ You are a meticulous editor checking whether a proposed patch resolves all liste
 **Issues to Resolve:**
 {{ issues_list }}
 
-Respond with a single line starting with a number from 0-100 indicating how well the patch resolves the issues (100 = fully resolved). Optionally add a short reason after the number.
+Respond with a single line beginning with a number from 0-100 indicating how well the patch resolves the issues (100 = fully resolved). Optionally add a brief reason after the number.

--- a/prompts/planner_agent/plan_continuation.j2
+++ b/prompts/planner_agent/plan_continuation.j2
@@ -1,6 +1,6 @@
 /no_think
 You are a master storyteller. Based on the provided summary, propose {{ num_points }} succinct future plot points for how the story could continue.
-Return only a JSON array of strings.
+Output only a JSON array of strings.
 
 Summary:
 {{ summary }}

--- a/prompts/planner_agent/scene_plan.j2
+++ b/prompts/planner_agent/scene_plan.j2
@@ -14,7 +14,7 @@ You are an expert novelist and storyteller, acting as a "showrunner" to plan out
 **Instructions for Planning:**
 1.  **Create a Narrative Arc:** Your plan should have a clear beginning, middle, and end for the chapter, fully exploring and resolving the `Main Plot Point`.
 2.  **Scene Variety is CRITICAL:** Plan a sequence of {{ target_scenes_min }} to {{ target_scenes_max }} scenes. Your plan must create a compelling narrative rhythm. Do not just write a series of similar scenes. You **MUST** vary the `scene_type` and `pacing` throughout the chapter. For example, follow a tense dialogue scene with a quiet, introspective scene, or an action scene with an atmospheric one.
-3.  **Output JSON Only:** Your entire output must be a single, valid JSON array of scene objects. Do not include any text or explanations outside of the JSON array.
+3.  **Output JSON Only:** Your entire output must be a single, valid JSON array of scene objects. Do not include any text or explanations outside the JSON array.
 4.  **Populate All Fields:** For each scene object in the JSON array, you must provide values for all the following keys:
     - `scene_number` (int): Sequential number for the scene.
     - `summary` (str): A concise summary of the scene's events.


### PR DESCRIPTION
## Summary
- polish bootstrapper prompt wording
- improve KG maintainer prompt text
- clarify patch replacement example
- refine planner and drafting prompts
- tweak patch validation instructions

## Testing
- `ruff check . && ruff format --check .`
- `pytest tests/ -v --cov=. --cov-report=term-missing`
- `mypy .`

------
https://chatgpt.com/codex/tasks/task_e_685abb726140832fb364977579a32590