### PR TITLE
Improve narrative guidance in prompts

### DIFF
--- a/processing/revision_logic.py
+++ b/processing/revision_logic.py
@@ -345,8 +345,9 @@ A chill traced Elara's spine, not from the crypt's cold, but from the translucen
             "4.  If the best way to fix the problem is to **completely remove** the 'Original Quote' segment (e.g., it is redundant or unnecessary), then you **MUST output an empty string**. Do not write a justification; simply provide no text as the `replace_with` output.",
             # MODIFICATION END
             "5.  Maintain the novel's style, tone, and consistency with all provided context (Novel Context, Plan, Hybrid Context).",
-            "6.  If `length_expansion_instruction_header_str` is present, ensure substantial expansion as guided for the targeted segment or new passage.",
-            '7.  **Output ONLY the `replace_with` text.** Do NOT include JSON, markdown, explanations, or any "Replace with:" prefixes. Just the raw text intended for replacement/insertion. (See example above for how to format the text).',
+            "6.  Convey thematic elements through subtext, character actions, and metaphorical imagery rather than direct exposition or deus ex machina fixes.",
+            "7.  If `length_expansion_instruction_header_str` is present, ensure substantial expansion as guided for the targeted segment or new passage.",
+            '8.  **Output ONLY the `replace_with` text.** Do NOT include JSON, markdown, explanations, or any "Replace with:" prefixes. Just the raw text intended for replacement/insertion. (See example above for how to format the text).',
             "",
             f'--- BEGIN REPLACE_WITH TEXT (for the segment related to "{original_quote_text_from_problem}" or as a new passage if quote is "N/A - General Issue") ---',
         ]

--- a/prompts/drafting_agent/draft_chapter_from_plot_point.j2
+++ b/prompts/drafting_agent/draft_chapter_from_plot_point.j2
@@ -20,7 +20,7 @@ You are an expert novelist tasked with writing the complete narrative text for a
 1.  **Write the ENTIRE text for Chapter {{ chapter_number }}.**
 2.  Your primary directive is to bring the "Plot Point Focus" to life as a complete, compelling chapter.
 3.  Ensure your writing is consistent with the information provided in the "Hybrid Context" to maintain narrative flow and canonical accuracy.
-4.  Produce a rich, detailed narrative. Incorporate descriptive language, character introspection, dialogue, and action as appropriate for the genre and plot point.
+4.  Produce a rich, detailed narrative. Convey the chapter's themes through character actions, subtext, and metaphorical imagery. Avoid heavy-handed exposition, lengthy monologues, or contrived deus ex machina solutions.
 5.  The chapter should be substantial in length, aiming for at least {{ min_length }} characters of high-quality prose.
 6.  **Output ONLY the chapter text.** Do not include a "Chapter {{ chapter_number }}" header, a title, author commentary, or any other meta discussion. Begin directly with the first sentence of the chapter.
 

--- a/prompts/drafting_agent/draft_scene.j2
+++ b/prompts/drafting_agent/draft_scene.j2
@@ -25,6 +25,7 @@ You are an expert novelist tasked with writing a single scene.
 1. Write the narrative prose for this scene only. Do not include headings or meta commentary.
 2. Ensure the prose aligns with the Hybrid Context and Prior Scene Prose.
 3. Aim for at least {{ min_length_per_scene }} characters of text.
-4. Output ONLY the scene text.
+4. Let the scene's themes emerge through action, subtext, and metaphorical imagery rather than direct exposition or deus ex machina.
+5. Output ONLY the scene text.
 
 --- BEGIN SCENE {{ scene_detail.scene_number }} TEXT ---

--- a/prompts/planner_agent/plan_continuation.j2
+++ b/prompts/planner_agent/plan_continuation.j2
@@ -1,5 +1,5 @@
 /no_think
-You are a master storyteller. Based on the provided summary, propose {{ num_points }} succinct future plot points for how the story could continue.
+You are a master storyteller. Based on the provided summary, propose {{ num_points }} succinct future plot points for how the story could continue. Let these ideas arise organically from prior events and character motivations; avoid deus ex machina twists.
 Output only a JSON array of strings.
 
 Summary:

--- a/prompts/planner_agent/scene_plan.j2
+++ b/prompts/planner_agent/scene_plan.j2
@@ -14,8 +14,9 @@ You are an expert novelist and storyteller, acting as a "showrunner" to plan out
 **Instructions for Planning:**
 1.  **Create a Narrative Arc:** Your plan should have a clear beginning, middle, and end for the chapter, fully exploring and resolving the `Main Plot Point`.
 2.  **Scene Variety is CRITICAL:** Plan a sequence of {{ target_scenes_min }} to {{ target_scenes_max }} scenes. Your plan must create a compelling narrative rhythm. Do not just write a series of similar scenes. You **MUST** vary the `scene_type` and `pacing` throughout the chapter. For example, follow a tense dialogue scene with a quiet, introspective scene, or an action scene with an atmospheric one.
-3.  **Output JSON Only:** Your entire output must be a single, valid JSON array of scene objects. Do not include any text or explanations outside the JSON array.
-4.  **Populate All Fields:** For each scene object in the JSON array, you must provide values for all the following keys:
+3.  **Convey Themes Implicitly:** Let the novel's themes surface through character actions, subtext, and metaphorical imagery rather than direct exposition or deus ex machina twists.
+4.  **Output JSON Only:** Your entire output must be a single, valid JSON array of scene objects. Do not include any text or explanations outside the JSON array.
+5.  **Populate All Fields:** For each scene object in the JSON array, you must provide values for all the following keys:
     - `scene_number` (int): Sequential number for the scene.
     - `summary` (str): A concise summary of the scene's events.
     - `characters_involved` (list[str]): A list of characters present.


### PR DESCRIPTION
## Summary
- refine chapter drafting instructions for subtler theme expression
- emphasize subtext and metaphor in scene drafting
- ensure scene plans and plot continuations avoid deus ex machina twists
- update patch revision prompts with thematic guidance

## Testing
- `ruff check . && ruff format --check .`
- `pytest tests/ -v --cov=. --cov-report=term-missing`
- `mypy .` *(fails: Library stubs not installed; many missing attributes)*

------
https://chatgpt.com/codex/tasks/task_e_685ae7b96810832fa025c74edf77799e