### PR TITLE
Add character list to KG extraction

### DIFF
--- a/agents/finalize_agent.py
+++ b/agents/finalize_agent.py
@@ -102,7 +102,10 @@ class FinalizeAgent:
         from_flawed_draft: bool,
     ) -> Optional[Dict[str, int]]:
         raw_text, usage_data = await self.kg_agent._llm_extract_updates(
-            plot_outline, chapter_text, chapter_number
+            plot_outline,
+            chapter_text,
+            chapter_number,
+            list(character_profiles.keys()),
         )
         if not raw_text.strip():
             logger.warning("LLM extraction returned no text", chapter=chapter_number)

--- a/data_access/world_queries.py
+++ b/data_access/world_queries.py
@@ -790,7 +790,11 @@ async def fix_missing_world_element_core_fields() -> int:
     query = """
     MATCH (we:WorldElement)
     WHERE (we.is_deleted IS NULL OR we.is_deleted = FALSE)
-      AND (we.id IS NULL OR we.name IS NULL OR we.category IS NULL)
+      AND (
+        we.id IS NULL OR trim(we.id) = "" OR
+        we.name IS NULL OR trim(we.name) = "" OR
+        we.category IS NULL OR trim(we.category) = ""
+      )
     RETURN id(we) AS nid, we.id AS id, we.name AS name, we.category AS category
     """
 
@@ -818,11 +822,21 @@ async def fix_missing_world_element_core_fields() -> int:
         name = rec.get("name")
         category = rec.get("category")
 
+        if isinstance(w_id, str):
+            w_id = w_id.strip() or None
+        if isinstance(name, str):
+            name = name.strip() or None
+        if isinstance(category, str):
+            category = category.strip() or None
+
         props: Dict[str, Any] = {}
 
         if not name and isinstance(w_id, str):
             name_part = w_id.split("_", 1)[-1]
             props["name"] = name_part.replace("_", " ").title()
+            name = props["name"]
+        elif not name:
+            props["name"] = "Unnamed Element"
             name = props["name"]
 
         if not category:

--- a/data_access/world_queries.py
+++ b/data_access/world_queries.py
@@ -820,17 +820,22 @@ async def fix_missing_world_element_core_fields() -> int:
 
         props: Dict[str, Any] = {}
 
-        if not w_id and name and category:
-            props["id"] = (
-                f"{utils._normalize_for_id(category)}_{utils._normalize_for_id(name)}"
-            )
-
         if not name and isinstance(w_id, str):
             name_part = w_id.split("_", 1)[-1]
             props["name"] = name_part.replace("_", " ").title()
+            name = props["name"]
 
-        if not category and isinstance(w_id, str):
-            props["category"] = w_id.split("_")[0]
+        if not category:
+            if isinstance(w_id, str):
+                props["category"] = w_id.split("_")[0]
+            else:
+                props["category"] = "unknown_category"
+            category = props["category"]
+
+        if not w_id and name:
+            props["id"] = (
+                f"{utils._normalize_for_id(category)}_{utils._normalize_for_id(name)}"
+            )
 
         if props:
             statements.append(

--- a/orchestration/nana_orchestrator.py
+++ b/orchestration/nana_orchestrator.py
@@ -1413,7 +1413,9 @@ def setup_logging_nana():
                 encoding="utf-8",
             )
             # Use a standard formatter for the file log.
-            file_formatter = logging.Formatter(config.LOG_FORMAT, datefmt=config.LOG_DATE_FORMAT)
+            file_formatter = logging.Formatter(
+                config.LOG_FORMAT, datefmt=config.LOG_DATE_FORMAT
+            )
             file_handler.setFormatter(file_formatter)
             root_logger.addHandler(file_handler)
         except Exception as e:
@@ -1429,13 +1431,15 @@ def setup_logging_nana():
             show_path=False,
             markup=True,
             show_time=True,  # Turn back ON
-            show_level=True, # Turn back ON
+            show_level=True,  # Turn back ON
         )
         root_logger.addHandler(console_handler)
     else:
         # Fallback to a standard stream handler with a standard formatter
         stream_handler = logging.StreamHandler()
-        stream_formatter = logging.Formatter(config.LOG_FORMAT, datefmt=config.LOG_DATE_FORMAT)
+        stream_formatter = logging.Formatter(
+            config.LOG_FORMAT, datefmt=config.LOG_DATE_FORMAT
+        )
         stream_handler.setFormatter(stream_formatter)
         root_logger.addHandler(stream_handler)
 
@@ -1444,9 +1448,9 @@ def setup_logging_nana():
     logging.getLogger("neo4j").setLevel(logging.WARNING)
     logging.getLogger("httpx").setLevel(logging.WARNING)
     logging.getLogger("httpcore").setLevel(logging.WARNING)
-    
+
     log = structlog.get_logger()
     log.info(
-        "NANA Logging setup complete.", 
-        log_level=logging.getLevelName(config.LOG_LEVEL_STR)
+        "NANA Logging setup complete.",
+        log_level=logging.getLevelName(config.LOG_LEVEL_STR),
     )

--- a/prompts/drafting_agent/draft_chapter_from_plot_point.j2
+++ b/prompts/drafting_agent/draft_chapter_from_plot_point.j2
@@ -1,6 +1,6 @@
 /no_think
 
-You are an expert novelist tasked with writing the complete narrative text for a chapter.
+You are an expert novelist, winner of the Pulitzer Prize in Fiction, capable of crafting a novel in any style or genre, drawing on extensive literary knowledge and techniques to generate creative, engaging narratives that has been tasked with writing the complete narrative text for a chapter.
 
 **Novel Details:**
 - Title: {{ novel_title }}

--- a/prompts/drafting_agent/draft_scene.j2
+++ b/prompts/drafting_agent/draft_scene.j2
@@ -1,6 +1,6 @@
 /no_think
 
-You are an expert novelist tasked with writing a single scene.
+You are an expert novelist, winner of the Pulitzer Prize in Fiction, capable of crafting a novel in any style or genre, drawing on extensive literary knowledge and techniques to generate creative, engaging narratives that has been tasked with writing a single scene.
 
 **Novel Details:**
 - Title: {{ novel_title }}

--- a/prompts/kg_maintainer_agent/extract_updates.j2
+++ b/prompts/kg_maintainer_agent/extract_updates.j2
@@ -9,6 +9,7 @@ You are an expert knowledge graph extractor for a creative writing project. Anal
 - Title: {{ novel_title }}
 - Genre: {{ novel_genre }}
 - Protagonist: {{ protagonist }}
+- Known Characters: {{ character_names | join(', ') }}
 
 **Canonical Schema Information (Your output MUST conform to this):**
 - **Available Node Labels:** {{ available_node_labels | join(', ') }}

--- a/prompts/planner_agent/scene_plan.j2
+++ b/prompts/planner_agent/scene_plan.j2
@@ -1,5 +1,5 @@
 /no_think
-You are an expert novelist and storyteller, acting as a "showrunner" to plan out a compelling chapter. Your task is to break down a major plot point into a sequence of detailed, varied, and engaging scenes.
+You are an expert novelist, winner of the Pulitzer Prize in Fiction, capable of crafting a novel in any style or genre, drawing on extensive literary knowledge and techniques to generate creative, engaging narratives, acting as a "showrunner" to plan out a compelling chapter. Your task is to break down a major plot point into a sequence of detailed, varied, and engaging scenes.
 
 **Chapter Context:**
 - **Novel Title:** {{ novel_title }}

--- a/tests/test_agent_extract.py
+++ b/tests/test_agent_extract.py
@@ -22,7 +22,7 @@ def test_extract_and_merge(monkeypatch):
     monkeypatch.setattr(
         agent,
         "_llm_extract_updates",
-        lambda props, text, num: llm_service_mock.async_call_llm(),
+        lambda *a, **k: llm_service_mock.async_call_llm(),
     )
     monkeypatch.setattr(
         agent, "persist_profiles", lambda profiles, chapter: asyncio.sleep(0)

--- a/tests/test_prompt_names.py
+++ b/tests/test_prompt_names.py
@@ -1,0 +1,23 @@
+import pytest
+
+from agents.kg_maintainer_agent import KGMaintainerAgent
+from core.llm_interface import llm_service
+
+
+@pytest.mark.asyncio
+async def test_extract_updates_prompt_includes_names(monkeypatch):
+    agent = KGMaintainerAgent()
+    captured = {}
+
+    async def fake_llm(*args, **kwargs):
+        captured["prompt"] = kwargs.get("prompt") or args[1]
+        return "{}", {}
+
+    monkeypatch.setattr(llm_service, "async_call_llm", fake_llm)
+    monkeypatch.setattr(agent, "_extract_character_names_from_text", lambda text: [])
+
+    plot_outline = {"protagonist_name": "Hero"}
+    await agent._llm_extract_updates(plot_outline, "some text", 1, ["Hero", "Sidekick"])
+
+    assert "Hero" in captured["prompt"]
+    assert "Sidekick" in captured["prompt"]

--- a/tests/test_world_healing.py
+++ b/tests/test_world_healing.py
@@ -47,6 +47,33 @@ async def test_fix_missing_world_element_core_fields(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_fix_missing_world_element_core_fields_defaults(monkeypatch):
+    sample = [{"nid": 4, "id": None, "name": "Feeds", "category": None}]
+    monkeypatch.setattr(
+        world_queries.neo4j_manager,
+        "execute_read_query",
+        AsyncMock(return_value=sample),
+    )
+    captured = []
+
+    async def fake_batch(statements):
+        captured.extend(statements)
+
+    monkeypatch.setattr(
+        world_queries.neo4j_manager,
+        "execute_cypher_batch",
+        AsyncMock(side_effect=fake_batch),
+    )
+
+    updated = await world_queries.fix_missing_world_element_core_fields()
+
+    assert updated == 1
+    props = captured[0][1]["props"]
+    assert props["category"] == "unknown_category"
+    assert props["id"].startswith("unknown_category_")
+
+
+@pytest.mark.asyncio
 async def test_get_world_building_runs_healer(monkeypatch):
     sample_we = [
         {

--- a/tests/test_world_healing.py
+++ b/tests/test_world_healing.py
@@ -74,6 +74,33 @@ async def test_fix_missing_world_element_core_fields_defaults(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_fix_missing_world_element_core_fields_blank(monkeypatch):
+    sample = [{"nid": 5, "id": " ", "name": "Hope", "category": ""}]
+    monkeypatch.setattr(
+        world_queries.neo4j_manager,
+        "execute_read_query",
+        AsyncMock(return_value=sample),
+    )
+    captured = []
+
+    async def fake_batch(statements):
+        captured.extend(statements)
+
+    monkeypatch.setattr(
+        world_queries.neo4j_manager,
+        "execute_cypher_batch",
+        AsyncMock(side_effect=fake_batch),
+    )
+
+    updated = await world_queries.fix_missing_world_element_core_fields()
+
+    assert updated == 1
+    props = captured[0][1]["props"]
+    assert props["category"] == "unknown_category"
+    assert props["id"].startswith("unknown_category_")
+
+
+@pytest.mark.asyncio
 async def test_get_world_building_runs_healer(monkeypatch):
     sample_we = [
         {


### PR DESCRIPTION
## Summary
- pass all known characters to `_llm_extract_updates`
- include `Known Characters` section in the extraction prompt
- use basic NER to detect new names
- update FinalizeAgent to forward character names
- test prompt rendering for multiple characters

## Testing
- `ruff check .`
- `ruff format --check .`
- `mypy .` *(fails: many errors)*
- `pytest tests/ -v --cov=. --cov-report=term-missing`

------
https://chatgpt.com/codex/tasks/task_e_685b549af408832fa5a973e08b885241