### PR TITLE
Fix: Correctly access temperature setting in bootstrapper

### DIFF
--- a/initialization/bootstrappers/common.py
+++ b/initialization/bootstrappers/common.py
@@ -27,7 +27,7 @@ async def bootstrap_field(
     response_text, usage_data = await llm_service.async_call_llm(
         model_name=settings.INITIAL_SETUP_MODEL,
         prompt=prompt,
-        temperature=settings.Temperatures.INITIAL_SETUP,
+        temperature=settings.TEMPERATURE_INITIAL_SETUP,
         stream_to_disk=False,
         auto_clean_response=True,
     )


### PR DESCRIPTION
The `SagaSettings` object does not have a nested `Temperatures` attribute. This commit updates the `bootstrap_field` function in `initialization/bootstrappers/common.py` to access the initial setup temperature directly via `settings.TEMPERATURE_INITIAL_SETUP` instead of attempting to access it through `settings.Temperatures.INITIAL_SETUP`.