### PR TITLE
refactor(cli): use structlog logger

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,11 +1,11 @@
 import argparse
 import asyncio
-import logging
 
+import structlog
 from core.db_manager import neo4j_manager
 from orchestration.nana_orchestrator import NANA_Orchestrator, setup_logging_nana
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- swap out `logging.getLogger` for `structlog.get_logger`

## Testing
- `ruff check .` *(fails: E501 line too long)*
- `ruff format --check .`
- `pytest tests/ -v --cov=. --cov-report=term-missing` *(fails: coverage < 85% and 7 tests failing)*
- `mypy .` *(fails: found errors in 24 files)*

------
https://chatgpt.com/codex/tasks/task_e_685c25ae35b8832fa9e6c82dc8c21a30