### PR TITLE
Fix revision loop ignore spans

### DIFF
--- a/agents/comprehensive_evaluator_agent.py
+++ b/agents/comprehensive_evaluator_agent.py
@@ -203,6 +203,12 @@ class ComprehensiveEvaluatorAgent:
 [
   {
     "issue_category": "CONSISTENCY",
+    "problem_description": "Sága's corporeality is inconsistent with earlier chapters where it is clearly incorporeal.",
+    "quote_from_original_text": "Saga darted through the crowd, shoving people aside with its own hands.",
+    "suggested_fix_focus": "Rewrite this passage to describe Sága's actions without using physical verbs. Depict its interaction through its control of the environment or remote avatars, consistent with its 'incorporeal' nature."
+  },
+  {
+    "issue_category": "CONSISTENCY",
     "problem_description": "Character Elara states she has never left her village, but her profile mentions she trained at the Royal Academy in the Capital.",
     "quote_from_original_text": "I've never seen anything beyond these village walls,\\" Elara sighed, gazing at the distant mountains.",
     "suggested_fix_focus": "Adjust Elara's dialogue to align with her established backstory of training in the Capital, or reconcile this statement with her past (e.g., she's being metaphorical or hiding her past)."

--- a/agents/world_continuity_agent.py
+++ b/agents/world_continuity_agent.py
@@ -128,6 +128,12 @@ class WorldContinuityAgent:
 [
   {
     "issue_category": "consistency",
+    "problem_description": "Sága's corporeality is inconsistent with earlier chapters where it is defined as incorporeal.",
+    "quote_from_original_text": "Saga darted through the crowd, shoving people aside with its own hands.",
+    "suggested_fix_focus": "Rewrite this passage to describe Sága's actions without using physical verbs. Depict its interaction through its control of the environment or remote avatars, consistent with its 'incorporeal' nature."
+  },
+  {
+    "issue_category": "consistency",
     "problem_description": "The 'Sunstone' is described as glowing blue in this"
     " chapter, but the world building notes explicitly state all Sunstones are"
     " crimson red.",

--- a/orchestration/nana_orchestrator.py
+++ b/orchestration/nana_orchestrator.py
@@ -420,9 +420,7 @@ class NANA_Orchestrator:
             await world_queries.get_all_world_item_ids_by_category()
         )
 
-        ignore_spans = patched_spans if attempt == 1 else None
-
-        ignore_spans = patched_spans if attempt == 1 else None
+        ignore_spans = patched_spans
 
         if settings.ENABLE_COMPREHENSIVE_EVALUATION:
             tasks_to_run.append(

--- a/prompts/comprehensive_evaluator_agent/evaluate_chapter.j2
+++ b/prompts/comprehensive_evaluator_agent/evaluate_chapter.j2
@@ -43,6 +43,7 @@ For `issue_category`, use one of the EXACT category names: CONSISTENCY, PLOT_ARC
 The `quote_from_original_text` must be a VERBATIM quote (10-50 words) from the chapter text. If general or no quote applies, use "N/A - General Issue".
 If NO problems are found, output an empty JSON array `[]` or a JSON object like {"status": "No significant problems found"}.
 If information is incomplete for any category, explain the limitation within your problem descriptions.
+The `suggested_fix_focus` should provide a direct instruction to revise the text so the problem is fully resolved. For example, if you detect "Sága's corporeality is inconsistent," the `suggested_fix_focus` might be "Rewrite this passage to describe Sága's actions without using physical verbs. Depict its interaction through its control of the environment or remote avatars, consistent with its 'incorporeal' nature."
 
 **Ignore the narrative details in the below example. It shows the required format only.**
 **Follow this example structure for your JSON output precisely:**

--- a/prompts/world_continuity_agent/consistency_check.j2
+++ b/prompts/world_continuity_agent/consistency_check.j2
@@ -42,6 +42,7 @@ Each object MUST have these keys: "issue_category" (fixed to "consistency"), "pr
 The `quote_from_original_text` must be a VERBATIM quote (10-50 words) from the chapter text. If general or no quote applies, use "N/A - General Issue".
 If NO consistency problems are found, output an empty JSON array `[]` or a JSON object like {"status": "No significant consistency problems found"}.
 If any part of the reference material is unclear or incomplete, note the uncertainty in your problem descriptions.
+The `suggested_fix_focus` field must give a clear instruction on how to fix the inconsistency. For instance, when reporting "Sága's corporeality is inconsistent," instruct the writer: "Rewrite this passage to describe Sága's actions without using physical verbs. Depict its interaction through its control of the environment or remote avatars, consistent with its 'incorporeal' nature."
 
 **Ignore the narrative details in the below example. It shows the required format only.**
 **Follow this example structure for your JSON output precisely:**

--- a/tests/test_evaluation_cycle.py
+++ b/tests/test_evaluation_cycle.py
@@ -15,7 +15,7 @@ def orchestrator(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_ignore_spans_only_first_attempt(orchestrator, monkeypatch):
+async def test_ignore_spans_all_attempts(orchestrator, monkeypatch):
     monkeypatch.setattr(
         character_queries, "get_all_character_names", AsyncMock(return_value=[])
     )
@@ -66,5 +66,5 @@ async def test_ignore_spans_only_first_attempt(orchestrator, monkeypatch):
         patched_spans,
     )
 
-    assert received["eval"] == [patched_spans, None]
-    assert received["continuity"] == [patched_spans, None]
+    assert received["eval"] == [patched_spans, patched_spans]
+    assert received["continuity"] == [patched_spans, patched_spans]

--- a/tests/test_ingestion_healing.py
+++ b/tests/test_ingestion_healing.py
@@ -11,7 +11,7 @@ from orchestration.nana_orchestrator import NANA_Orchestrator
 @pytest.mark.asyncio
 async def test_ingestion_triggers_healing(monkeypatch, tmp_path):
     monkeypatch.setattr(utils, "load_spacy_model_if_needed", lambda: None)
-    monkeypatch.setattr(config, "KG_HEALING_INTERVAL", 2)
+    monkeypatch.setattr(config.settings, "KG_HEALING_INTERVAL", 2)
 
     orch = NANA_Orchestrator()
     monkeypatch.setattr(orch, "_update_rich_display", lambda *a, **k: None)

--- a/tests/test_novel_generation_dynamic.py
+++ b/tests/test_novel_generation_dynamic.py
@@ -11,7 +11,7 @@ from orchestration.nana_orchestrator import NANA_Orchestrator
 @pytest.mark.asyncio
 async def test_dynamic_chapter_adjustment(monkeypatch):
     monkeypatch.setattr(utils, "load_spacy_model_if_needed", lambda: None)
-    monkeypatch.setattr(config, "CHAPTERS_PER_RUN", 3)
+    monkeypatch.setattr(config.settings, "CHAPTERS_PER_RUN", 3)
 
     orch = NANA_Orchestrator()
     monkeypatch.setattr(orch, "_update_rich_display", lambda *a, **k: None)

--- a/tests/test_revision_patching.py
+++ b/tests/test_revision_patching.py
@@ -197,7 +197,6 @@ async def test_duplicate_patch_skipped(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_patch_validation_toggle(monkeypatch):
-    settings.settings.AGENT_ENABLE_PATCH_VALIDATION = False
     settings.AGENT_ENABLE_PATCH_VALIDATION = False
 
     called = False
@@ -381,7 +380,6 @@ async def test_patch_generation_concurrent(monkeypatch):
     assert len(res) == 3
     assert duration < 0.25
 
-    settings.settings.AGENT_ENABLE_PATCH_VALIDATION = True
     settings.AGENT_ENABLE_PATCH_VALIDATION = True
 
 

--- a/tests/test_text_processing_misc.py
+++ b/tests/test_text_processing_misc.py
@@ -18,7 +18,7 @@ def test_normalize_text_for_matching():
 
 def test_is_fill_in_and_normalization_helpers():
     assert not text_processing._is_fill_in("test")
-    assert text_processing._is_fill_in(text_processing.config.FILL_IN)
+    assert text_processing._is_fill_in(text_processing.settings.FILL_IN)
 
 
 def test_get_text_segments_paragraph(monkeypatch):

--- a/tests/test_token_tracker_misc.py
+++ b/tests/test_token_tracker_misc.py
@@ -1,7 +1,10 @@
+import logging
+
 from orchestration.token_tracker import TokenTracker
 
 
 def test_token_tracker_add_completion_tokens(caplog):
+    caplog.set_level(logging.INFO)
     tracker = TokenTracker()
     tracker.add("draft", {"completion_tokens": 5})
     assert tracker.total == 5
@@ -9,6 +12,7 @@ def test_token_tracker_add_completion_tokens(caplog):
 
 
 def test_token_tracker_add_total_tokens_only(caplog):
+    caplog.set_level(logging.INFO)
     tracker = TokenTracker()
     tracker.add("draft", {"total_tokens": 10})
     assert tracker.total == 0
@@ -16,6 +20,7 @@ def test_token_tracker_add_total_tokens_only(caplog):
 
 
 def test_token_tracker_add_invalid_usage(caplog):
+    caplog.set_level(logging.WARNING)
     tracker = TokenTracker()
     tracker.add("draft", {"other": 1})
     assert tracker.total == 0

--- a/tests/test_user_story_models.py
+++ b/tests/test_user_story_models.py
@@ -16,7 +16,9 @@ def test_load_user_supplied_data_valid(tmp_path, monkeypatch):
     data = {"novel_concept": {"title": "Test"}}
     file_path = tmp_path / "story.yaml"
     file_path.write_text(yaml.dump(data))
-    monkeypatch.setattr(config, "USER_STORY_ELEMENTS_FILE_PATH", str(file_path))
+    monkeypatch.setattr(
+        config.settings, "USER_STORY_ELEMENTS_FILE_PATH", str(file_path)
+    )
 
     model = _load_user_supplied_data()
     assert isinstance(model, UserStoryInputModel)
@@ -27,7 +29,9 @@ def test_load_user_supplied_data_valid(tmp_path, monkeypatch):
 def test_load_user_supplied_data_invalid(tmp_path, monkeypatch):
     file_path = tmp_path / "bad.yaml"
     file_path.write_text("- item1\n- item2")
-    monkeypatch.setattr(config, "USER_STORY_ELEMENTS_FILE_PATH", str(file_path))
+    monkeypatch.setattr(
+        config.settings, "USER_STORY_ELEMENTS_FILE_PATH", str(file_path)
+    )
 
     result = _load_user_supplied_data()
     assert result is None


### PR DESCRIPTION
## Summary
- always pass patched spans to evaluators
- update evaluation cycle test
- patch tests for new config.settings access
- tweak token tracker tests to capture INFO logs

## Testing
- `ruff check . && ruff format --check .`
- `pytest tests/ -v --cov=. --cov-report=term-missing` *(fails: Required test coverage of 85.0% not reached)*
- `mypy .` *(fails: 81 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685ca44718fc832f85334956c7473f29