### PR TITLE
Improve revision resilience and KG enrichment

### DIFF
--- a/initialization/genesis.py
+++ b/initialization/genesis.py
@@ -77,4 +77,8 @@ async def run_genesis_phase() -> tuple[
     )
     logger.info("Knowledge graph pre-population complete (full sync).")
 
+    # New enrichment pass to clarify ambiguous concepts before drafting begins
+    await kg_agent.heal_and_enrich_kg()
+    logger.info("Initial KG enrichment pass executed.")
+
     return plot_outline, character_profiles, world_items_for_kg, usage_totals

--- a/orchestration/nana_orchestrator.py
+++ b/orchestration/nana_orchestrator.py
@@ -736,9 +736,11 @@ class NANA_Orchestrator:
                     f"NANA: Ch {novel_chapter_number} - Revision attempt {attempt} failed to produce usable text. Proceeding with previous draft, marked as flawed."
                 )
                 self._update_rich_display(
-                    step=f"Ch {novel_chapter_number} - Revision Failed (Flawed)"
+                    step=f"Ch {novel_chapter_number} - Revision Failed (Retrying)"
                 )
-                break
+                revisions_made += 1
+                needs_revision = True
+                continue
 
         return (
             current_text,

--- a/processing/revision_logic.py
+++ b/processing/revision_logic.py
@@ -367,6 +367,7 @@ A chill traced Elara's spine, not from the crypt's cold, but from the translucen
             "2.  Generate a `replace_with` text according to the following:",
             prompt_instruction_for_replacement_scope_str,
             '3.  The `replace_with` text MUST address the "Problem Description" and "Suggested Fix Focus".',
+            "   Follow the 'Suggested Fix Focus' EXACTLY, e.g., 'Rewrite this paragraph so the protagonist thinks before acting, but without using any verbs that imply a physical body.'",
             # MODIFICATION START: Added instruction for deletion via empty string.
             "4.  If the best way to fix the problem is to **completely remove** the 'Original Quote' segment (e.g., it is redundant or unnecessary), then you **MUST output an empty string**. Do not write a justification; simply provide no text as the `replace_with` output.",
             # MODIFICATION END

--- a/tests/test_revision_loop.py
+++ b/tests/test_revision_loop.py
@@ -1,0 +1,53 @@
+import pytest
+from orchestration.nana_orchestrator import NANA_Orchestrator
+
+
+class DummyOrchestrator(NANA_Orchestrator):
+    def __init__(self):
+        super().__init__()
+        self.plot_outline = {"plot_points": ["a"]}
+
+
+@pytest.mark.asyncio
+async def test_revision_loop_retries_on_failure(monkeypatch):
+    orch = DummyOrchestrator()
+    monkeypatch.setattr(orch, "_update_rich_display", lambda *a, **k: None)
+
+    async def _noop(*_a, **_k):
+        return None
+
+    monkeypatch.setattr(orch, "_save_debug_output", _noop)
+    monkeypatch.setattr(orch, "_accumulate_tokens", lambda *a, **k: None)
+
+    async def fake_eval(*_args, **_kwargs):
+        return (
+            {"needs_revision": True, "problems_found": [], "reasons": ["bad"]},
+            [],
+            {},
+            {},
+        )
+
+    call_counter = {"count": 0}
+
+    async def fake_perform(*_args, **_kwargs):
+        call_counter["count"] += 1
+        if call_counter["count"] == 1:
+            return "start", None, [], {}
+        return "fixed", "raw", [], {}
+
+    monkeypatch.setattr(orch, "_run_evaluation_cycle", fake_eval)
+    monkeypatch.setattr(orch, "_perform_revisions", fake_perform)
+
+    result = await orch._run_revision_loop(
+        1,
+        "start",
+        "raw",
+        "focus",
+        0,
+        "ctx",
+        None,
+        [],
+        False,
+    )
+    assert result[0] == "fixed"
+    assert call_counter["count"] == 2


### PR DESCRIPTION
## Summary
- retry failed chapter revisions instead of aborting
- require revision prompts follow the evaluator's suggested fix focus
- run a knowledge graph enrichment pass after bootstrapping
- test revision loop retries on failure

## Testing
- `ruff check . && ruff format --check .`
- `mypy .` *(fails: several incompatible type errors)*
- `pytest tests/test_revision_loop.py -v` *(fails coverage: total of 14 is less than fail-under=85)*
- `pytest tests/ -v --cov=. --cov-report=term-missing` *(fails coverage: total of 40.90% < 85)*

------
https://chatgpt.com/codex/tasks/task_e_685ce7860910832f9de45af6d188535e