### PR TITLE
refactor(initialization): delegate world bootstrap

### DIFF
--- a/initialization/bootstrappers/world_bootstrapper.py
+++ b/initialization/bootstrappers/world_bootstrapper.py
@@ -27,11 +27,10 @@ WORLD_DETAIL_LIST_INTERNAL_KEYS: list[str] = []
 async def generate_world_building_logic(
     world_building: dict[str, Any], plot_outline: dict[str, Any]
 ) -> tuple[dict[str, Any], dict[str, int] | None]:
-    """Stub world-building generation function."""
-    logger.warning("generate_world_building_logic stub called")
+    """Generate complete world-building information."""
     if not world_building:
         world_building = create_default_world()
-    return world_building, None
+    return await bootstrap_world(world_building, plot_outline)
 
 
 def create_default_world() -> dict[str, dict[str, WorldItem]]:

--- a/tests/test_initial_setup_logic.py
+++ b/tests/test_initial_setup_logic.py
@@ -66,7 +66,7 @@ async def test_valid_json_output_from_llm(agent_instance):
     )
 
     with patch(
-        "initialization.bootstrappers.world_bootstrapper.llm_service.async_call_llm",
+        "initialization.bootstrappers.common.llm_service.async_call_llm",
         AsyncMock(return_value=mock_llm_output),
     ) as mocked_llm_call:
         wb, _ = await generate_world_building_logic(
@@ -119,7 +119,7 @@ async def test_invalid_json_output_decode_error(agent_instance):
     initial_setting_desc = agent_instance.plot_outline["setting"]
 
     with patch(
-        "initialization.bootstrappers.world_bootstrapper.llm_service.async_call_llm",
+        "initialization.bootstrappers.common.llm_service.async_call_llm",
         AsyncMock(return_value=mock_llm_output),
     ):
         wb, _ = await generate_world_building_logic(
@@ -161,7 +161,7 @@ async def test_llm_provides_string_for_expected_list(agent_instance):
     )
 
     with patch(
-        "initialization.bootstrappers.world_bootstrapper.llm_service.async_call_llm",
+        "initialization.bootstrappers.common.llm_service.async_call_llm",
         AsyncMock(return_value=mock_llm_output),
     ):
         wb, _ = await generate_world_building_logic(
@@ -196,7 +196,7 @@ async def test_llm_provides_integer_for_expected_list(agent_instance):
     )
 
     with patch(
-        "initialization.bootstrappers.world_bootstrapper.llm_service.async_call_llm",
+        "initialization.bootstrappers.common.llm_service.async_call_llm",
         AsyncMock(return_value=mock_llm_output),
     ):
         wb, _ = await generate_world_building_logic(
@@ -234,7 +234,7 @@ async def test_llm_output_missing_category(agent_instance):
     )
 
     with patch(
-        "initialization.bootstrappers.world_bootstrapper.llm_service.async_call_llm",
+        "initialization.bootstrappers.common.llm_service.async_call_llm",
         AsyncMock(return_value=mock_llm_output),
     ):
         wb, _ = await generate_world_building_logic(
@@ -278,7 +278,7 @@ async def test_llm_output_empty_list_for_list_field(agent_instance):
     )
 
     with patch(
-        "initialization.bootstrappers.world_bootstrapper.llm_service.async_call_llm",
+        "initialization.bootstrappers.common.llm_service.async_call_llm",
         AsyncMock(return_value=mock_llm_output),
     ):
         wb, _ = await generate_world_building_logic(
@@ -355,7 +355,7 @@ async def test_existing_user_data_preserved_and_llm_fills_gaps(agent_instance):
     )
 
     with patch(
-        "initialization.bootstrappers.world_bootstrapper.llm_service.async_call_llm",
+        "initialization.bootstrappers.common.llm_service.async_call_llm",
         AsyncMock(return_value=mock_llm_output),
     ):
         wb, _ = await generate_world_building_logic(
@@ -472,7 +472,7 @@ async def test_generate_world_building_mixed_llm_output_format(agent_instance):
     # Patch the global list within the 'world_bootstrapper' module for the duration of this test
     with (
         patch(
-            "initialization.bootstrappers.world_bootstrapper.llm_service.async_call_llm",
+            "initialization.bootstrappers.common.llm_service.async_call_llm",
             AsyncMock(return_value=mock_llm_return),
         ),
         patch(


### PR DESCRIPTION
## Summary
- remove stub world-building generator
- delegate world building to `bootstrap_world`
- update tests to patch new module path

## Testing
- `ruff check .`
- `ruff format --check .`
- `pytest tests/ -v --cov=. --cov-report=term-missing` *(fails: Required test coverage of 85.0% not reached)*
- `mypy .` *(fails: 79 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685dbf7e71fc832f9f7d12899489fdd0