### PR TITLE
Introduce typed models for initialization

### DIFF
--- a/initialization/bootstrappers/character_bootstrapper.py
+++ b/initialization/bootstrappers/character_bootstrapper.py
@@ -1,11 +1,11 @@
 import asyncio
 from collections.abc import Coroutine
-from typing import Any
 
 import structlog
 import utils
 from config import settings
-from kg_maintainer.models import CharacterProfile
+
+from initialization.models import CharacterProfile, PlotOutline
 
 from .common import bootstrap_field
 
@@ -22,7 +22,7 @@ def create_default_characters(protagonist_name: str) -> dict[str, CharacterProfi
 
 async def bootstrap_characters(
     character_profiles: dict[str, CharacterProfile],
-    plot_outline: dict[str, Any],
+    plot_outline: PlotOutline,
 ) -> tuple[dict[str, CharacterProfile], dict[str, int] | None]:
     """Fill missing character profile data via LLM."""
     tasks: dict[tuple[str, str], Coroutine] = {}

--- a/initialization/bootstrappers/plot_bootstrapper.py
+++ b/initialization/bootstrappers/plot_bootstrapper.py
@@ -1,41 +1,42 @@
 import asyncio
 from collections.abc import Coroutine
-from typing import Any
 
 import structlog
 import utils
 from config import settings
+
+from initialization.models import PlotOutline
 
 from .common import bootstrap_field
 
 logger = structlog.get_logger(__name__)
 
 
-def create_default_plot(default_protagonist_name: str) -> dict[str, Any]:
+def create_default_plot(default_protagonist_name: str) -> PlotOutline:
     """Create a default plot outline with placeholders."""
     num_points = settings.TARGET_PLOT_POINTS_INITIAL_GENERATION
-    return {
-        "title": settings.DEFAULT_PLOT_OUTLINE_TITLE,
-        "protagonist_name": default_protagonist_name,
-        "genre": settings.CONFIGURED_GENRE,
-        "setting": settings.CONFIGURED_SETTING_DESCRIPTION,
-        "theme": settings.CONFIGURED_THEME,
-        "logline": settings.FILL_IN,
-        "inciting_incident": settings.FILL_IN,
-        "central_conflict": settings.FILL_IN,
-        "stakes": settings.FILL_IN,
-        "plot_points": [f"{settings.FILL_IN}" for _ in range(num_points)],
-        "narrative_style": settings.FILL_IN,
-        "tone": settings.FILL_IN,
-        "pacing": settings.FILL_IN,
-        "is_default": True,
-        "source": "default_fallback",
-    }
+    return PlotOutline(
+        title=settings.DEFAULT_PLOT_OUTLINE_TITLE,
+        protagonist_name=default_protagonist_name,
+        genre=settings.CONFIGURED_GENRE,
+        setting=settings.CONFIGURED_SETTING_DESCRIPTION,
+        theme=settings.CONFIGURED_THEME,
+        logline=settings.FILL_IN,
+        inciting_incident=settings.FILL_IN,
+        central_conflict=settings.FILL_IN,
+        stakes=settings.FILL_IN,
+        plot_points=[f"{settings.FILL_IN}" for _ in range(num_points)],
+        narrative_style=settings.FILL_IN,
+        tone=settings.FILL_IN,
+        pacing=settings.FILL_IN,
+        is_default=True,
+        source="default_fallback",
+    )
 
 
 async def bootstrap_plot_outline(
-    plot_outline: dict[str, Any],
-) -> tuple[dict[str, Any], dict[str, int] | None]:
+    plot_outline: PlotOutline,
+) -> tuple[PlotOutline, dict[str, int] | None]:
     """Fill missing plot fields via LLM."""
     tasks: dict[str, Coroutine] = {}
     usage_data: dict[str, int] = {

--- a/initialization/bootstrappers/world_bootstrapper.py
+++ b/initialization/bootstrappers/world_bootstrapper.py
@@ -1,11 +1,11 @@
 import asyncio
 from collections.abc import Coroutine
-from typing import Any
 
 import structlog
 import utils
 from config import settings
-from kg_maintainer.models import WorldItem
+
+from initialization.models import PlotOutline, WorldBuilding, WorldItem
 
 from .common import bootstrap_field
 
@@ -25,15 +25,15 @@ WORLD_DETAIL_LIST_INTERNAL_KEYS: list[str] = []
 
 
 async def generate_world_building_logic(
-    world_building: dict[str, Any], plot_outline: dict[str, Any]
-) -> tuple[dict[str, Any], dict[str, int] | None]:
+    world_building: WorldBuilding, plot_outline: PlotOutline
+) -> tuple[WorldBuilding, dict[str, int] | None]:
     """Generate complete world-building information."""
-    if not world_building:
+    if not world_building or not world_building.data:
         world_building = create_default_world()
     return await bootstrap_world(world_building, plot_outline)
 
 
-def create_default_world() -> dict[str, dict[str, WorldItem]]:
+def create_default_world() -> WorldBuilding:
     """Create a default world-building structure."""
     world_data: dict[str, dict[str, WorldItem]] = {
         "_overview_": {
@@ -68,13 +68,13 @@ def create_default_world() -> dict[str, dict[str, WorldItem]]:
             )
         }
 
-    return world_data
+    return WorldBuilding(data=world_data, is_default=True, source="default_fallback")
 
 
 async def bootstrap_world(
-    world_building: dict[str, Any],
-    plot_outline: dict[str, Any],
-) -> tuple[dict[str, Any], dict[str, int] | None]:
+    world_building: WorldBuilding,
+    plot_outline: PlotOutline,
+) -> tuple[WorldBuilding, dict[str, int] | None]:
     """Fill missing world-building information via LLM."""
     overall_usage_data: dict[str, int] = {
         "prompt_tokens": 0,

--- a/initialization/data_loader.py
+++ b/initialization/data_loader.py
@@ -1,11 +1,11 @@
-from typing import Any
-
 import structlog
 from config import settings
-from kg_maintainer.models import CharacterProfile, WorldItem
-from models.user_input_models import UserStoryInputModel, user_story_to_objects
 from pydantic import ValidationError
 from yaml_parser import load_yaml_file
+
+from models.user_input_models import UserStoryInputModel, user_story_to_objects
+
+from .models import CharacterProfile, PlotOutline, WorldBuilding
 
 logger = structlog.get_logger(__name__)
 
@@ -24,10 +24,9 @@ def load_user_supplied_model() -> UserStoryInputModel | None:
 
 def convert_model_to_objects(
     model: UserStoryInputModel,
-) -> tuple[
-    dict[str, Any],
-    dict[str, CharacterProfile],
-    dict[str, dict[str, WorldItem]],
-]:
+) -> tuple[PlotOutline, dict[str, CharacterProfile], WorldBuilding]:
     """Convert a validated model into internal objects."""
-    return user_story_to_objects(model)
+    plot_data, characters, world_items = user_story_to_objects(model)
+    plot_outline = PlotOutline(**plot_data)
+    world_building = WorldBuilding(data=world_items)
+    return plot_outline, characters, world_building

--- a/initialization/models.py
+++ b/initialization/models.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from models import CharacterProfile as BaseCharacterProfile
+from models import WorldItem
+from models.agent_models import AgentBaseModel
+
+
+class PlotOutline(AgentBaseModel):
+    """Structured representation of the plot outline."""
+
+    title: str | None = None
+    protagonist_name: str | None = None
+    genre: str | None = None
+    setting: str | None = None
+    theme: str | None = None
+    logline: str | None = None
+    inciting_incident: str | None = None
+    central_conflict: str | None = None
+    stakes: str | None = None
+    plot_points: list[str] = Field(default_factory=list)
+    narrative_style: str | None = None
+    tone: str | None = None
+    pacing: str | None = None
+    is_default: bool | None = None
+    source: str | None = None
+
+    def setdefault(
+        self, key: str, default: Any
+    ) -> Any:  # pragma: no cover - convenience
+        val = self.get(key)
+        if val is None:
+            self[key] = default
+            return default
+        return val
+
+
+class CharacterProfile(BaseCharacterProfile):
+    """Alias for character profiles used during initialization."""
+
+
+class WorldBuilding(BaseModel):
+    """Container for world building items keyed by category."""
+
+    model_config = ConfigDict(extra="allow")
+
+    data: dict[str, dict[str, WorldItem]] = Field(default_factory=dict)
+    is_default: bool | None = None
+    source: str | None = None
+
+    def __getitem__(
+        self, key: str
+    ) -> dict[str, WorldItem]:  # pragma: no cover - convenience
+        return self.data[key]
+
+    def __setitem__(
+        self, key: str, value: Any
+    ) -> None:  # pragma: no cover - convenience
+        if key == "is_default":
+            self.is_default = bool(value)
+        elif key == "source":
+            self.source = str(value)
+        else:
+            self.data[key] = value
+
+    def get(
+        self, key: str, default: Any = None
+    ) -> Any:  # pragma: no cover - convenience
+        if key in {"is_default", "source"}:
+            return getattr(self, key, default)
+        return self.data.get(key, default)
+
+    def items(
+        self,
+    ) -> Iterable[tuple[str, dict[str, WorldItem]]]:  # pragma: no cover - convenience
+        return self.data.items()
+
+    def __contains__(self, key: str) -> bool:  # pragma: no cover - convenience
+        return key in self.data
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {"is_default": self.is_default, "source": self.source}
+        result.update(self.data)
+        return result
+
+
+__all__ = ["PlotOutline", "CharacterProfile", "WorldBuilding", "WorldItem"]

--- a/tests/test_novel_generation_dynamic.py
+++ b/tests/test_novel_generation_dynamic.py
@@ -5,6 +5,7 @@ import pytest
 import utils
 from core.db_manager import neo4j_manager
 from data_access import chapter_queries
+from initialization.models import PlotOutline
 from orchestration.nana_orchestrator import NANA_Orchestrator
 
 
@@ -16,7 +17,7 @@ async def test_dynamic_chapter_adjustment(monkeypatch):
     orch = NANA_Orchestrator()
     monkeypatch.setattr(orch, "_update_rich_display", lambda *a, **k: None)
 
-    orch.plot_outline = {"title": "T", "plot_points": ["p1", "p2"]}
+    orch.plot_outline = PlotOutline(title="T", plot_points=["p1", "p2"])
     orch.chapter_count = 0
 
     calls = []

--- a/tests/test_orchestrator_private_methods.py
+++ b/tests/test_orchestrator_private_methods.py
@@ -3,6 +3,9 @@ from unittest.mock import AsyncMock
 import pytest
 import utils
 from data_access import character_queries, world_queries
+from initialization.models import PlotOutline
+from orchestration.nana_orchestrator import NANA_Orchestrator
+
 from models.user_input_models import (
     KeyLocationModel,
     NovelConceptModel,
@@ -10,7 +13,6 @@ from models.user_input_models import (
     SettingModel,
     UserStoryInputModel,
 )
-from orchestration.nana_orchestrator import NANA_Orchestrator
 
 
 @pytest.fixture
@@ -23,7 +25,7 @@ def orchestrator(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_validate_plot_outline_missing(orchestrator):
-    orchestrator.plot_outline = {}
+    orchestrator.plot_outline = PlotOutline()
     assert not await orchestrator._validate_plot_outline(1)
 
 
@@ -80,7 +82,7 @@ def test_load_state_from_user_model(orchestrator):
 
 @pytest.mark.asyncio
 async def test_prepare_prerequisites_uses_plan(orchestrator, monkeypatch):
-    orchestrator.plot_outline = {"plot_points": ["Intro"]}
+    orchestrator.plot_outline = PlotOutline(plot_points=["Intro"])
     monkeypatch.setattr(orchestrator, "_update_novel_props_cache", lambda: None)
 
     async def fake_plan(*_args, **_kwargs):

--- a/tests/test_revision_loop.py
+++ b/tests/test_revision_loop.py
@@ -2,13 +2,14 @@ from unittest.mock import AsyncMock
 
 import pytest
 from data_access import character_queries, world_queries
+from initialization.models import PlotOutline
 from orchestration.nana_orchestrator import NANA_Orchestrator
 
 
 class DummyOrchestrator(NANA_Orchestrator):
     def __init__(self):
         super().__init__()
-        self.plot_outline = {"plot_points": ["a"]}
+        self.plot_outline = PlotOutline(plot_points=["a"])
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- define PlotOutline, CharacterProfile and WorldBuilding models
- return these models from `convert_model_to_objects`
- update bootstrappers and `run_genesis_phase` to use models
- adjust orchestrator and tests for new types

## Testing
- `ruff check . && ruff format --check .`
- `mypy .` *(fails: Missing named argument "LOG_LEVEL" for "SagaSettings" and more)*
- `pytest tests/ -v --cov=. --cov-report=term-missing` *(fails: Required test coverage of 85% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_685dcb2abd38832f8853d1a83f241223