### PR TITLE
Fix PlotOutline JSON serialization

### DIFF
--- a/agents/comprehensive_evaluator_agent.py
+++ b/agents/comprehensive_evaluator_agent.py
@@ -6,7 +6,6 @@ import utils  # MODIFIED: For spaCy functions
 from config import settings
 from core.llm_interface import llm_service  # MODIFIED
 from data_access import chapter_queries
-from models import EvaluationResult, ProblemDetail
 from processing.problem_parser import parse_problem_list
 from prompt_data_getters import (
     get_filtered_character_profiles_for_prompt_plain_text,
@@ -14,6 +13,8 @@ from prompt_data_getters import (
     get_reliable_kg_facts_for_drafting_prompt,
 )
 from prompt_renderer import render_prompt
+
+from models import EvaluationResult, ProblemDetail
 
 logger = structlog.get_logger(__name__)
 

--- a/agents/drafting_agent.py
+++ b/agents/drafting_agent.py
@@ -4,8 +4,9 @@ from typing import Any
 import structlog
 from config import settings
 from core.llm_interface import count_tokens, llm_service, truncate_text_by_tokens
-from models import SceneDetail
 from prompt_renderer import render_prompt
+
+from models import SceneDetail
 
 logger = structlog.get_logger(__name__)
 

--- a/agents/finalize_agent.py
+++ b/agents/finalize_agent.py
@@ -7,10 +7,10 @@ import numpy as np
 import structlog
 from core.llm_interface import llm_service
 from data_access import chapter_queries, kg_queries
-from models import CharacterProfile, WorldItem
 from parsing_utils import parse_rdf_triples_with_rdflib
 
 from agents.kg_maintainer_agent import KGMaintainerAgent
+from models import CharacterProfile, WorldItem
 
 logger = structlog.get_logger(__name__)
 

--- a/agents/patch_validation_agent.py
+++ b/agents/patch_validation_agent.py
@@ -1,8 +1,9 @@
 import structlog
 from config import settings
 from core.llm_interface import llm_service
-from models import PatchInstruction, ProblemDetail
 from prompt_renderer import render_prompt
+
+from models import PatchInstruction, ProblemDetail
 
 logger = structlog.get_logger(__name__)
 

--- a/agents/planner_agent.py
+++ b/agents/planner_agent.py
@@ -7,13 +7,14 @@ import structlog
 from config import settings
 from core.llm_interface import llm_service
 from data_access import chapter_queries
-from models import CharacterProfile, SceneDetail, WorldItem
 from prompt_data_getters import (
     get_character_state_snippet_for_prompt,
     get_reliable_kg_facts_for_drafting_prompt,
     get_world_state_snippet_for_prompt,
 )
 from prompt_renderer import render_prompt
+
+from models import CharacterProfile, SceneDetail, WorldItem
 
 logger = structlog.get_logger(__name__)
 

--- a/agents/world_continuity_agent.py
+++ b/agents/world_continuity_agent.py
@@ -9,13 +9,14 @@ import utils  # MODIFIED: For spaCy functions
 from config import settings
 from core.llm_interface import llm_service  # MODIFIED
 from data_access import character_queries, kg_queries, world_queries
-from models import ProblemDetail, SceneDetail
 from processing.problem_parser import parse_problem_list
 from prompt_data_getters import (
     get_filtered_character_profiles_for_prompt_plain_text,
     get_filtered_world_data_for_prompt_plain_text,
 )
 from prompt_renderer import render_prompt
+
+from models import ProblemDetail, SceneDetail
 
 logger = structlog.get_logger(__name__)
 

--- a/processing/context_generator.py
+++ b/processing/context_generator.py
@@ -17,8 +17,9 @@ from core.llm_interface import (
 from data_access import (
     chapter_queries,
 )  # For chapter data and similarity search
-from models import SceneDetail
 from prompt_data_getters import get_reliable_kg_facts_for_drafting_prompt
+
+from models import SceneDetail
 
 logger = structlog.get_logger(__name__)
 

--- a/processing/patch_generator.py
+++ b/processing/patch_generator.py
@@ -9,6 +9,7 @@ import utils
 from agents.patch_validation_agent import PatchValidationAgent
 from config import settings
 from core.llm_interface import count_tokens, llm_service
+
 from models import PatchInstruction, ProblemDetail, SceneDetail
 
 logger = structlog.get_logger(__name__)

--- a/processing/revision_logic.py
+++ b/processing/revision_logic.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import structlog
 import utils  # For numpy_cosine_similarity, find_semantically_closest_segment, AND find_quote_and_sentence_offsets_with_spacy, format_scene_plan_for_prompt
+
 from models import (
     CharacterProfile,
     EvaluationResult,

--- a/processing/revision_manager.py
+++ b/processing/revision_manager.py
@@ -5,6 +5,7 @@ from agents.comprehensive_evaluator_agent import ComprehensiveEvaluatorAgent
 from agents.patch_validation_agent import PatchValidationAgent
 from config import settings
 from core.llm_interface import llm_service, truncate_text_by_tokens
+
 from models import (
     CharacterProfile,
     EvaluationResult,

--- a/prompt_renderer.py
+++ b/prompt_renderer.py
@@ -2,8 +2,9 @@
 """Utilities for rendering LLM prompts using Jinja2 templates."""
 
 import json
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 from jinja2 import Environment, FileSystemLoader
 from jinja2.utils import htmlsafe_json_dumps
@@ -20,6 +21,13 @@ def _default_json_serializer(value: Any) -> Any:
     raise TypeError(
         f"Object of type {value.__class__.__name__} is not JSON serializable"
     )
+
+
+_env.policies["json.dumps_function"] = lambda obj, **kw: json.dumps(
+    obj,
+    default=_default_json_serializer,
+    **kw,
+)
 
 
 def _tojson(value: Any, indent: int | None = None) -> str:

--- a/tests/test_prompt_renderer_misc.py
+++ b/tests/test_prompt_renderer_misc.py
@@ -23,3 +23,14 @@ def test_render_prompt_with_pydantic_object(monkeypatch):
     monkeypatch.setattr(prompt_renderer, "_env", env)
     result = prompt_renderer.render_prompt("greet.j2", {"person": Person(name="Alice")})
     assert result == "Hello Alice"
+
+
+def test_tojson_with_pydantic_object(monkeypatch):
+    env = Environment(
+        loader=DictLoader({"obj.j2": "{{ person | tojson }}"}),
+        autoescape=False,
+    )
+    env.filters["tojson"] = prompt_renderer._tojson
+    monkeypatch.setattr(prompt_renderer, "_env", env)
+    result = prompt_renderer.render_prompt("obj.j2", {"person": Person(name="Alice")})
+    assert result == '{"name": "Alice"}'

--- a/tests/test_user_story_models.py
+++ b/tests/test_user_story_models.py
@@ -3,6 +3,7 @@ import yaml
 from initialization.data_loader import (
     load_user_supplied_model as _load_user_supplied_data,
 )
+
 from models.user_input_models import (
     CharacterGroupModel,
     NovelConceptModel,


### PR DESCRIPTION
## Summary
- patch `prompt_renderer` to provide JSON serializer for Pydantic models
- test that `tojson` handles Pydantic objects
- address ruff lint import sorting

## Testing
- `ruff check . && ruff format --check .`
- `mypy .` *(fails: 85 errors)*
- `pytest tests/ -v --cov=. --cov-report=term-missing` *(fails: coverage < 85%)*

------
https://chatgpt.com/codex/tasks/task_e_685dd31a7a88832fabd1acb829ac0368