### PR TITLE
Fix EvaluationResult handling in revision service

### DIFF
--- a/chapter_generation/revision_service.py
+++ b/chapter_generation/revision_service.py
@@ -87,7 +87,10 @@ class RevisionService:
                 continuity_usage,
             )
 
-            evaluation_result: EvaluationResult = EvaluationResult(**eval_result_obj)
+            if isinstance(eval_result_obj, EvaluationResult):
+                evaluation_result: EvaluationResult = eval_result_obj
+            else:
+                evaluation_result = EvaluationResult(**eval_result_obj)
             await self.orchestrator._save_debug_output(
                 chapter_number,
                 f"evaluation_result_attempt_{attempt}",


### PR DESCRIPTION
## Summary
- handle `EvaluationResult` instances or dicts in revision service

## Testing
- `ruff check .`
- `ruff format --check .`
- `pytest -q`
- `mypy .` *(fails: Found 84 errors in 27 files)*

------
https://chatgpt.com/codex/tasks/task_e_685de6fa08cc832fb7fa1c470bee602e