### PR TITLE
Refactor pipeline to dataclasses

### DIFF
--- a/chapter_generation/__init__.py
+++ b/chapter_generation/__init__.py
@@ -1,14 +1,16 @@
 """Utilities for orchestrating chapter generation steps."""
 
-from .drafting_service import DraftingService
+from .drafting_service import DraftingService, DraftResult
 from .evaluation_service import EvaluationCycleResult, EvaluationService
 from .finalization_service import FinalizationService
-from .prerequisites_service import PrerequisitesService
+from .prerequisites_service import PrerequisiteData, PrerequisitesService
 from .revision_service import RevisionResult, RevisionService
 
 __all__ = [
     "PrerequisitesService",
+    "PrerequisiteData",
     "DraftingService",
+    "DraftResult",
     "EvaluationService",
     "EvaluationCycleResult",
     "RevisionService",

--- a/chapter_generation/drafting_service.py
+++ b/chapter_generation/drafting_service.py
@@ -2,12 +2,21 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - type hint import
     from orchestration.nana_orchestrator import NANA_Orchestrator
 
     from models import SceneDetail
+
+
+@dataclass
+class DraftResult:
+    """Initial draft and raw output from the DraftingAgent."""
+
+    text: str | None
+    raw_llm_output: str | None
 
 
 class DraftingService:
@@ -22,10 +31,11 @@ class DraftingService:
         plot_point_focus: str,
         hybrid_context_for_draft: str,
         chapter_plan: list[SceneDetail] | None,
-    ) -> tuple[str | None, str | None]:
-        return await self.orchestrator._draft_initial_chapter_text(
+    ) -> DraftResult:
+        result_text, raw_llm = await self.orchestrator._draft_initial_chapter_text(
             chapter_number,
             plot_point_focus,
             hybrid_context_for_draft,
             chapter_plan,
         )
+        return DraftResult(text=result_text, raw_llm_output=raw_llm)

--- a/chapter_generation/prerequisites_service.py
+++ b/chapter_generation/prerequisites_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from models import SceneDetail
@@ -10,13 +11,21 @@ if TYPE_CHECKING:  # pragma: no cover - type hint import
     from orchestration.nana_orchestrator import NANA_Orchestrator
 
 
+@dataclass
+class PrerequisiteData:
+    """Data required before drafting a chapter."""
+
+    plot_point_focus: str | None
+    plot_point_index: int
+    chapter_plan: list[SceneDetail] | None
+    hybrid_context_for_draft: str | None
+
+
 class PrerequisitesService:
     """Service for preparing chapter prerequisites."""
 
     def __init__(self, orchestrator: NANA_Orchestrator) -> None:
         self.orchestrator = orchestrator
 
-    async def prepare(
-        self, chapter_number: int
-    ) -> tuple[str | None, int, list[SceneDetail] | None, str | None]:
+    async def prepare(self, chapter_number: int) -> PrerequisiteData:
         return await self.orchestrator._prepare_chapter_prerequisites(chapter_number)

--- a/orchestration/chapter_flow.py
+++ b/orchestration/chapter_flow.py
@@ -25,9 +25,10 @@ async def run_chapter_pipeline(
     )
     if processed_prereqs is None:
         return None
-    plot_point_focus, plot_point_index, chapter_plan, hybrid_context_for_draft = (
-        processed_prereqs
-    )
+    plot_point_focus = processed_prereqs.plot_point_focus
+    plot_point_index = processed_prereqs.plot_point_index
+    chapter_plan = processed_prereqs.chapter_plan
+    hybrid_context_for_draft = processed_prereqs.hybrid_context_for_draft
 
     draft_result = await orchestrator.drafting_service.draft_initial_text(
         novel_chapter_number,
@@ -40,7 +41,8 @@ async def run_chapter_pipeline(
     )
     if processed_draft is None:
         return None
-    initial_draft_text, initial_raw_llm_text = processed_draft
+    initial_draft_text = processed_draft.text
+    initial_raw_llm_text = processed_draft.raw_llm_output
 
     revision_result = await orchestrator._process_and_revise_draft(
         novel_chapter_number,
@@ -56,7 +58,9 @@ async def run_chapter_pipeline(
     )
     if processed_revision is None:
         return None
-    processed_text, processed_raw_llm, is_flawed = processed_revision
+    processed_text = processed_revision.text
+    processed_raw_llm = processed_revision.raw_llm_output
+    is_flawed = processed_revision.is_flawed
 
     return await orchestrator._finalize_and_log(
         novel_chapter_number, processed_text, processed_raw_llm, is_flawed

--- a/tests/test_chapter_flow.py
+++ b/tests/test_chapter_flow.py
@@ -1,5 +1,8 @@
 import pytest
+from chapter_generation.drafting_service import DraftResult
+from chapter_generation.prerequisites_service import PrerequisiteData
 from orchestration import chapter_flow
+from orchestration.nana_orchestrator import RevisionOutcome
 
 
 class DummyOrchestrator:
@@ -19,27 +22,30 @@ class DummyOrchestrator:
         return self.values.get("validate", True)
 
     async def _prepare_chapter_prerequisites(self, chapter):
-        return self.values.get("prereq", object())
-
-    async def _process_prereq_result(self, chapter, prereq_result):
         return self.values.get(
-            "process_prereqs",
-            ("focus", 1, "plan", "ctx"),
+            "prereq",
+            PrerequisiteData("focus", 1, "plan", "ctx"),
         )
 
+    async def _process_prereq_result(self, chapter, prereq_result):
+        return self.values.get("process_prereqs", prereq_result)
+
     async def _draft_initial_chapter_text(self, *args):
-        return self.values.get("draft", "draft_res")
+        return self.values.get("draft", DraftResult("draft_res", "raw"))
 
     async def _process_initial_draft(self, chapter, draft_result):
-        return self.values.get("process_draft", ("txt", "raw"))
+        return self.values.get("process_draft", draft_result)
 
     async def _process_and_revise_draft(self, *args):
-        return self.values.get("revise", "revise_res")
+        return self.values.get(
+            "revise",
+            RevisionOutcome("revise_res", "raw", False),
+        )
 
     async def _process_revision_result(self, chapter, rev_res):
         return self.values.get(
             "process_revision",
-            ("processed", "raw", False),
+            RevisionOutcome("processed", "raw", False),
         )
 
     async def _finalize_and_log(self, *args):

--- a/tests/test_orchestrator_private_methods.py
+++ b/tests/test_orchestrator_private_methods.py
@@ -2,9 +2,11 @@ from unittest.mock import AsyncMock
 
 import pytest
 import utils
+from chapter_generation.drafting_service import DraftResult
+from chapter_generation.prerequisites_service import PrerequisiteData
 from data_access import character_queries, world_queries
 from initialization.models import PlotOutline
-from orchestration.nana_orchestrator import NANA_Orchestrator
+from orchestration.nana_orchestrator import NANA_Orchestrator, RevisionOutcome
 
 from models.user_input_models import (
     KeyLocationModel,
@@ -31,19 +33,23 @@ async def test_validate_plot_outline_missing(orchestrator):
 
 @pytest.mark.asyncio
 async def test_process_prereq_result_failure(orchestrator):
-    result = await orchestrator._process_prereq_result(1, (None, -1, None, None))
+    result = await orchestrator._process_prereq_result(
+        1, PrerequisiteData(None, -1, None, None)
+    )
     assert result is None
 
 
 @pytest.mark.asyncio
 async def test_process_initial_draft_failure(orchestrator):
-    result = await orchestrator._process_initial_draft(1, (None, None))
+    result = await orchestrator._process_initial_draft(1, DraftResult(None, None))
     assert result is None
 
 
 @pytest.mark.asyncio
 async def test_process_revision_result_failure(orchestrator):
-    result = await orchestrator._process_revision_result(1, (None, None, False))
+    result = await orchestrator._process_revision_result(
+        1, RevisionOutcome(None, None, False)
+    )
     assert result is None
 
 
@@ -119,4 +125,9 @@ async def test_prepare_prerequisites_uses_plan(orchestrator, monkeypatch):
     )
 
     result = await orchestrator._prepare_chapter_prerequisites(1)
-    assert result == ("Intro", 0, [{"scene_number": 1}], "ctx")
+    assert result == PrerequisiteData(
+        plot_point_focus="Intro",
+        plot_point_index=0,
+        chapter_plan=[{"scene_number": 1}],
+        hybrid_context_for_draft="ctx",
+    )


### PR DESCRIPTION
## Summary
- refactor orchestrator pipeline to return PrerequisiteData, DraftResult and RevisionOutcome objects
- update chapter_flow and services to work with dataclasses
- adjust tests for new return types

## Testing
- `ruff check .`
- `ruff format --check .`
- `pytest tests/ -v --cov=. --cov-report=term-missing` *(fails: Required test coverage of 85% not reached)*
- `mypy .` *(fails: found errors)*

------
https://chatgpt.com/codex/tasks/task_e_685deb28e6e8832f839544fc17f0d33f