### PR TITLE
Centralize plot point lookup

### DIFF
--- a/processing/revision_logic.py
+++ b/processing/revision_logic.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import structlog
 import utils  # For numpy_cosine_similarity, find_semantically_closest_segment, AND find_quote_and_sentence_offsets_with_spacy, format_scene_plan_for_prompt
+from utils.plot import get_plot_point_info
 
 from models import (
     CharacterProfile,
@@ -22,7 +23,7 @@ from . import patch_generator
 _get_formatted_scene_plan_from_agent_or_fallback = (
     patch_generator._get_formatted_scene_plan_from_agent_or_fallback
 )
-_get_plot_point_info = patch_generator._get_plot_point_info
+_get_plot_point_info = get_plot_point_info
 _get_context_window_for_patch_llm = patch_generator._get_context_window_for_patch_llm
 _get_sentence_embeddings = patch_generator._get_sentence_embeddings
 _find_sentence_via_embeddings = patch_generator._find_sentence_via_embeddings

--- a/processing/revision_manager.py
+++ b/processing/revision_manager.py
@@ -5,6 +5,7 @@ from agents.comprehensive_evaluator_agent import ComprehensiveEvaluatorAgent
 from agents.patch_validation_agent import PatchValidationAgent
 from config import settings
 from core.llm_interface import llm_service, truncate_text_by_tokens
+from utils.plot import get_plot_point_info
 
 from models import (
     CharacterProfile,
@@ -152,9 +153,7 @@ class RevisionManager:
                 for cat, items in world_building.items()
                 if isinstance(items, dict)
             }
-            plot_focus, plot_idx = patch_generator._get_plot_point_info(
-                plot_outline, chapter_number
-            )
+            plot_focus, plot_idx = get_plot_point_info(plot_outline, chapter_number)
             post_eval, post_usage = await evaluator.evaluate_chapter_draft(
                 plot_outline,
                 list(character_profiles.keys()),
@@ -189,7 +188,7 @@ class RevisionManager:
                 truncation_marker="\n... (original draft snippet truncated for brevity in rewrite prompt)",
             )
             plan_focus_section_full_rewrite_parts: list[str] = []
-            plot_point_focus_full_rewrite, _ = patch_generator._get_plot_point_info(
+            plot_point_focus_full_rewrite, _ = get_plot_point_info(
                 plot_outline, chapter_number
             )
             max_plan_tokens_for_full_rewrite = settings.MAX_CONTEXT_TOKENS // 2

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -12,6 +12,7 @@ from config import settings
 from core.llm_interface import count_tokens, llm_service
 
 from .helpers import _is_fill_in
+from .plot import get_plot_point_info
 from .similarity import find_semantically_closest_segment, numpy_cosine_similarity
 from .text_processing import (
     SpaCyModelManager,
@@ -228,6 +229,7 @@ __all__ = [
     "numpy_cosine_similarity",
     "get_text_segments",
     "format_scene_plan_for_prompt",
+    "get_plot_point_info",
     "deduplicate_text_segments",
     "remove_spans_from_text",
 ]

--- a/utils/plot.py
+++ b/utils/plot.py
@@ -1,0 +1,44 @@
+import logging
+from typing import Any
+
+from config import settings
+
+logger = logging.getLogger(__name__)
+
+
+def get_plot_point_info(
+    plot_outline: dict[str, Any], chapter_number: int
+) -> tuple[str | None, int]:
+    """Return plot point text and index for the chapter."""
+    plot_points = plot_outline.get("plot_points", [])
+    if not isinstance(plot_points, list) or not plot_points or chapter_number <= 0:
+        logger.error(
+            "No plot points available or invalid chapter number (%s).",
+            chapter_number,
+        )
+        return None, -1
+
+    plot_point_index = chapter_number - 1
+    if 0 <= plot_point_index < len(plot_points):
+        plot_point_item = plot_points[plot_point_index]
+        plot_point_text = (
+            plot_point_item.get("description")
+            if isinstance(plot_point_item, dict)
+            else str(plot_point_item)
+        )
+        if isinstance(plot_point_text, str) and plot_point_text.strip():
+            return plot_point_text, plot_point_index
+        logger.warning(
+            "Plot point at index %s for chapter %s is empty or invalid. Using placeholder.",
+            plot_point_index,
+            chapter_number,
+        )
+        return settings.FILL_IN, plot_point_index
+
+    logger.error(
+        "Plot point index %s is out of bounds for plot_points list (len: %s) for chapter %s.",
+        plot_point_index,
+        len(plot_points),
+        chapter_number,
+    )
+    return None, -1


### PR DESCRIPTION
## Summary
- move plot point lookup into `utils.plot.get_plot_point_info`
- replace duplicated logic in orchestrator and patch-related modules

## Testing
- `ruff check .`
- `ruff format --check .`
- `pytest tests/ -v --cov=. --cov-report=term-missing` *(fails: Required test coverage of 85% not reached)*
- `mypy .` *(fails: multiple type errors)*

------
https://chatgpt.com/codex/tasks/task_e_685df0e27d58832f99f80a5b5b3bd47c