### PR TITLE
Implement runtime KG caching

### DIFF
--- a/tests/test_orchestrator_private_methods.py
+++ b/tests/test_orchestrator_private_methods.py
@@ -114,6 +114,17 @@ async def test_prepare_prerequisites_uses_plan(orchestrator, monkeypatch):
         "get_world_building_from_db",
         AsyncMock(return_value={}),
     )
+    await orchestrator.refresh_knowledge_cache()
+    monkeypatch.setattr(
+        character_queries,
+        "get_character_profiles_from_db",
+        AsyncMock(side_effect=Exception("cache not used")),
+    )
+    monkeypatch.setattr(
+        world_queries,
+        "get_world_building_from_db",
+        AsyncMock(side_effect=Exception("cache not used")),
+    )
     monkeypatch.setattr(
         orchestrator.world_continuity_agent,
         "check_scene_plan_consistency",

--- a/tests/test_orchestrator_refresh.py
+++ b/tests/test_orchestrator_refresh.py
@@ -2,7 +2,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 import utils
-from data_access import plot_queries
+from data_access import character_queries, plot_queries, world_queries
 from orchestration.nana_orchestrator import NANA_Orchestrator
 
 
@@ -23,3 +23,20 @@ async def test_refresh_plot_outline(orchestrator, monkeypatch):
     )
     await orchestrator.refresh_plot_outline()
     assert orchestrator.plot_outline["plot_points"] == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_refresh_knowledge_cache(orchestrator, monkeypatch):
+    monkeypatch.setattr(
+        character_queries,
+        "get_character_profiles_from_db",
+        AsyncMock(return_value={"hero": object()}),
+    )
+    monkeypatch.setattr(
+        world_queries,
+        "get_world_building_from_db",
+        AsyncMock(return_value={"places": {}}),
+    )
+    await orchestrator.refresh_knowledge_cache()
+    assert "hero" in orchestrator.knowledge_cache.characters
+    assert "places" in orchestrator.knowledge_cache.world


### PR DESCRIPTION
## Summary
- add `KnowledgeCache` for character profiles and world items
- load cache during orchestrator init and setup
- refresh cache after KG maintenance and ingestion
- use cached data when planning chapters
- test caching functionality

## Testing
- `ruff check .`
- `ruff format --check .`
- `pytest tests/ -v --cov=. --cov-report=term-missing` *(fails: ConnectionError: Neo4j driver not initialized or connection failed)*
- `mypy .` *(fails: numerous type errors)*

------
https://chatgpt.com/codex/tasks/task_e_685e0215d0cc832f99b89800715a067b