### PR TITLE
Fix DraftingService return value

### DIFF
--- a/chapter_generation/drafting_service.py
+++ b/chapter_generation/drafting_service.py
@@ -36,10 +36,10 @@ class DraftingService:
         hybrid_context_for_draft: str,
         chapter_plan: list[SceneDetail] | None,
     ) -> DraftResult:
-        result_text, raw_llm = await self.orchestrator._draft_initial_chapter_text(
+        draft_result = await self.orchestrator._draft_initial_chapter_text(
             chapter_number,
             plot_point_focus,
             hybrid_context_for_draft,
             chapter_plan,
         )
-        return DraftResult(text=result_text, raw_llm_output=raw_llm)
+        return draft_result


### PR DESCRIPTION
## Summary
- return dataclass directly from `DraftingService.draft_initial_text`

## Testing
- `ruff check . && ruff format --check .`
- `mypy .` *(fails: Missing named argument "LOG_LEVEL" and many other errors)*
- `pytest tests/ -v --cov=. --cov-report=term-missing` *(fails: Coverage failure: total of 44 is less than fail-under=85)*

------
https://chatgpt.com/codex/tasks/task_e_685e0c5b343c832fb224cbbd69aa66c9