### PR TITLE
Fix DraftResult unpacking

### DIFF
--- a/chapter_generation/drafting_service.py
+++ b/chapter_generation/drafting_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -18,6 +19,11 @@ class DraftResult:
 
     text: str | None
     raw_llm_output: str | None
+
+    def __iter__(self) -> Iterable[str | None]:
+        """Allow tuple-style unpacking of the draft result."""
+        yield self.text
+        yield self.raw_llm_output
 
 
 class DraftingService:

--- a/tests/test_drafting_service.py
+++ b/tests/test_drafting_service.py
@@ -1,0 +1,29 @@
+import pytest
+from chapter_generation.drafting_service import DraftingService, DraftResult
+
+
+class DummyFileManager:
+    pass
+
+
+class DummyOrchestrator:
+    async def _draft_initial_chapter_text(self, *args):
+        return DraftResult("draft", "raw")
+
+
+@pytest.mark.asyncio
+async def test_draft_initial_text_returns_dataclass():
+    service = DraftingService(DummyOrchestrator(), DummyFileManager())
+    result = await service.draft_initial_text(1, "focus", "ctx", None)
+    assert isinstance(result, DraftResult)
+    assert result.text == "draft"
+    assert result.raw_llm_output == "raw"
+
+
+@pytest.mark.asyncio
+async def test_draft_result_is_unpackable():
+    service = DraftingService(DummyOrchestrator(), DummyFileManager())
+    result = await service.draft_initial_text(1, "focus", "ctx", None)
+    text, raw = result
+    assert text == "draft"
+    assert raw == "raw"


### PR DESCRIPTION
## Summary
- add `__iter__` to `DraftResult` dataclass for unpacking support
- extend tests for unpacking behavior

## Testing
- `ruff check .`
- `ruff format --check .`
- `mypy .` *(fails: incompatible types in multiple modules)*
- `pytest tests/test_drafting_service.py -v` *(fails: Required test coverage of 85% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_685e0fb70714832f8e5f9541c0e119f5