### PR TITLE
Defer patch spaCy initialization

### DIFF
--- a/processing/patch/apply.py
+++ b/processing/patch/apply.py
@@ -22,6 +22,7 @@ async def _get_sentence_embeddings(
     """Return (start, end, embedding) for each sentence."""
     if cache is None:
         cache = _sentence_embedding_cache
+    utils.load_spacy_model_if_needed()
     text_hash = hashlib.sha256(text.encode("utf-8")).hexdigest()
     if text_hash in cache:
         return cache[text_hash]

--- a/processing/patch/context.py
+++ b/processing/patch/context.py
@@ -6,7 +6,6 @@ import utils
 from models import ProblemDetail, SceneDetail
 
 logger = structlog.get_logger(__name__)
-utils.load_spacy_model_if_needed()
 
 
 def _get_formatted_scene_plan_from_agent_or_fallback(

--- a/tests/test_revision_patching.py
+++ b/tests/test_revision_patching.py
@@ -233,6 +233,11 @@ async def test_patch_validation_toggle(monkeypatch):
         "_generate_single_patch_instruction_llm",
         fake_generate,
     )
+    monkeypatch.setattr(
+        patch_generator.instructions,
+        "_generate_single_patch_instruction_llm",
+        fake_generate,
+    )
 
     problems = [
         {
@@ -290,6 +295,7 @@ async def test_sentence_embedding_cache(monkeypatch):
         call_count += 1
         return np.array([1.0])
 
+    monkeypatch.setattr(utils, "load_spacy_model_if_needed", lambda: None)
     monkeypatch.setattr(llm_service, "async_get_embedding", fake_embed)
     cache: dict[str, list[tuple[int, int, object]]] = {}
     await patch_generator._get_sentence_embeddings(text, cache)
@@ -347,6 +353,11 @@ async def test_patch_generation_concurrent(monkeypatch):
 
     monkeypatch.setattr(
         patch_generator,
+        "_generate_single_patch_instruction_llm",
+        fake_generate,
+    )
+    monkeypatch.setattr(
+        patch_generator.instructions,
         "_generate_single_patch_instruction_llm",
         fake_generate,
     )


### PR DESCRIPTION
## Summary
- remove eager spaCy load in patch context
- load spaCy model lazily within `_get_sentence_embeddings`
- update patching tests for deferred loading

## Testing
- `ruff check . && ruff format --check .`
- `mypy . --install-types --non-interactive` *(fails: 98 errors)*
- `pytest tests/ -v --cov=. --cov-report=term-missing` *(fails: coverage < 85%)*

------
https://chatgpt.com/codex/tasks/task_e_685e2c5766a0832f8c10a172fda086e5