### PR TITLE
Add NoOpPatchValidator

### DIFF
--- a/agents/patch_validation_agent.py
+++ b/agents/patch_validation_agent.py
@@ -55,3 +55,20 @@ class PatchValidationAgent:
         if not is_pass:
             logger.info("Patch validation score %d below threshold", score)
         return is_pass, usage
+
+
+class NoOpPatchValidator(PatchValidationAgent):
+    """Bypass patch validation and always approve patches."""
+
+    def __init__(self) -> None:  # noqa: D401 - no behavior to document
+        """Initialize without calling the parent constructor."""
+        # Intentionally skip PatchValidationAgent initialization
+
+    async def validate_patch(
+        self,
+        context_snippet: str,
+        patch: PatchInstruction,
+        problems: list[ProblemDetail],
+    ) -> tuple[bool, None]:
+        """Return True without performing validation."""
+        return True, None

--- a/processing/revision_manager.py
+++ b/processing/revision_manager.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import structlog
 from agents.comprehensive_evaluator_agent import ComprehensiveEvaluatorAgent
-from agents.patch_validation_agent import PatchValidationAgent
+from agents.patch_validation_agent import NoOpPatchValidator, PatchValidationAgent
 from config import settings
 from core.llm_interface import llm_service, truncate_text_by_tokens
 from utils.plot import get_plot_point_info
@@ -108,14 +108,7 @@ class RevisionManager:
             if settings.AGENT_ENABLE_PATCH_VALIDATION:
                 validator: PatchValidationAgent | Any = PatchValidationAgent()
             else:
-
-                class _BypassValidator:
-                    async def validate_patch(
-                        self, *_args: Any, **_kwargs: Any
-                    ) -> tuple[bool, None]:
-                        return True, None
-
-                validator = _BypassValidator()
+                validator = NoOpPatchValidator()
 
             patcher = PatchGenerator()
             (


### PR DESCRIPTION
## Summary
- always approve patches with `NoOpPatchValidator`
- use the new validator when patch validation is disabled
- test that revision manager loads `NoOpPatchValidator`
- test the bypass validator directly

## Testing
- `ruff check .`
- `ruff format --check agents/patch_validation_agent.py processing/revision_manager.py tests/test_revision_manager_patch_generator.py`
- `pytest tests/ -v --cov=. --cov-report=term-missing`
- `mypy .`

------
https://chatgpt.com/codex/tasks/task_e_685e2f043f70832fb055c7c6818d6efa