### PR TITLE
Add TokenUsage dataclass and update patch workflow

### DIFF
--- a/core/usage.py
+++ b/core/usage.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class TokenUsage:
+    """LLM token usage metrics."""
+
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+
+    def add(self, usage: TokenUsage | dict[str, int] | None) -> None:
+        """Accumulate usage values from another instance or dictionary."""
+        if not usage:
+            return
+        if isinstance(usage, TokenUsage):
+            self.prompt_tokens += usage.prompt_tokens
+            self.completion_tokens += usage.completion_tokens
+            self.total_tokens += usage.total_tokens
+        else:
+            self.prompt_tokens += usage.get("prompt_tokens", 0)
+            self.completion_tokens += usage.get("completion_tokens", 0)
+            self.total_tokens += usage.get("total_tokens", 0)

--- a/processing/patch/__init__.py
+++ b/processing/patch/__init__.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 from agents.patch_validation_agent import PatchValidationAgent
+from core.usage import TokenUsage
 
 from models import ProblemDetail, SceneDetail
 
@@ -36,10 +37,10 @@ class PatchGenerator:
         chapter_plan: list[SceneDetail] | None,
         already_patched_spans: list[tuple[int, int]] | None,
         validator: PatchValidationAgent,
-    ) -> tuple[str, list[tuple[int, int]]]:
-        """Return revised text and updated spans after applying patches."""
+    ) -> tuple[str, list[tuple[int, int]], TokenUsage | None]:
+        """Return revised text, updated spans, and token usage."""
         sentence_embeddings = await _get_sentence_embeddings(original_text)
-        patch_instructions, _ = await _generate_patch_instructions_logic(
+        patch_instructions, usage = await _generate_patch_instructions_logic(
             plot_outline,
             original_text,
             problems_to_fix,
@@ -48,9 +49,10 @@ class PatchGenerator:
             chapter_plan,
             validator,
         )
-        return await _apply_patches_to_text(
+        patched_text, spans = await _apply_patches_to_text(
             original_text,
             patch_instructions,
             already_patched_spans,
             sentence_embeddings,
         )
+        return patched_text, spans, usage

--- a/tests/test_revision_manager_patch_generator.py
+++ b/tests/test_revision_manager_patch_generator.py
@@ -31,7 +31,7 @@ async def test_patch_generator_successful_application(monkeypatch):
     monkeypatch.setattr(patch_generator, "_apply_patches_to_text", fake_apply)
 
     patcher = patch_generator.PatchGenerator()
-    result, spans = await patcher.generate_and_apply(
+    result, spans, usage = await patcher.generate_and_apply(
         {"plot_points": ["a"]},
         "Hello world",
         [
@@ -53,6 +53,7 @@ async def test_patch_generator_successful_application(monkeypatch):
 
     assert result == "Hi world"
     assert spans == [(0, 2)]
+    assert usage is None
 
 
 @pytest.mark.asyncio
@@ -85,7 +86,7 @@ async def test_patch_generator_failed_validation(monkeypatch):
     )
 
     patcher = patch_generator.PatchGenerator()
-    result, spans = await patcher.generate_and_apply(
+    result, spans, usage = await patcher.generate_and_apply(
         {"plot_points": ["a"]},
         "Hello world",
         [
@@ -107,12 +108,13 @@ async def test_patch_generator_failed_validation(monkeypatch):
 
     assert result == "Hello world"
     assert spans == []
+    assert usage is None
 
 
 @pytest.mark.asyncio
 async def test_revision_manager_full_rewrite(monkeypatch):
     async def fake_generate_and_apply(*_args, **_kwargs):
-        return "Hello world", []
+        return "Hello world", [], None
 
     async def fake_call_llm(*_args, **_kwargs):
         return "Rewrite done", None
@@ -175,7 +177,7 @@ async def test_revision_manager_uses_noop_validator(monkeypatch):
             received = args[-1]
         else:
             received = _kwargs.get("validator")
-        return "Hello world", []
+        return "Hello world", [], None
 
     monkeypatch.setattr(
         patch_generator.PatchGenerator,


### PR DESCRIPTION
## Summary
- create `TokenUsage` dataclass for tracking token counts
- return token usage from `PatchGenerator.generate_and_apply`
- accumulate `TokenUsage` in `RevisionManager`
- update tests to check the new return signature

## Testing
- `ruff check . --select I --fix`
- `ruff format .`
- `ruff check .`
- `ruff format --check .`
- `pytest tests/ -v --cov=. --cov-report=term-missing` *(fails: Required test coverage of 85.0% not reached)*
- `pytest tests/ -v --cov=processing --cov=agents --cov=orchestration --cov-report=term-missing` *(fails: Required test coverage of 85.0% not reached)*
- `mypy .` *(fails: found errors)*

------
https://chatgpt.com/codex/tasks/task_e_685e31211bac832fbb90905cc27e445d