### PR TITLE
Add docstrings for revision pipeline

### DIFF
--- a/agents/patch_validation_agent.py
+++ b/agents/patch_validation_agent.py
@@ -21,7 +21,21 @@ class PatchValidationAgent:
         patch: PatchInstruction,
         problems: list[ProblemDetail],
     ) -> tuple[bool, dict[str, int] | None]:
-        """Return True if patch addresses all problems adequately."""
+        """Validate a single patch against reported problems.
+
+        Args:
+            context_snippet: Portion of chapter text surrounding the problem.
+            patch: Proposed patch instruction to validate.
+            problems: Collection of issues the patch should address.
+
+        Returns:
+            A tuple where the first element indicates whether the patch passed
+            validation and the second contains optional token usage data from the
+            LLM call.
+
+        Side Effects:
+            Sends a prompt to the LLM service and logs diagnostic information.
+        """
 
         issues_list = "\n".join(f"- {p['problem_description']}" for p in problems)
         prompt = render_prompt(
@@ -70,5 +84,18 @@ class NoOpPatchValidator(PatchValidationAgent):
         patch: PatchInstruction,
         problems: list[ProblemDetail],
     ) -> tuple[bool, None]:
-        """Return True without performing validation."""
+        """Approve patches without validation.
+
+        Args:
+            context_snippet: Unused text snippet from the chapter.
+            patch: Patch instruction being "validated".
+            problems: Original list of problems for context.
+
+        Returns:
+            ``True`` with ``None`` for usage to mimic the real validator's
+            return type.
+
+        Side Effects:
+            None.
+        """
         return True, None

--- a/processing/patch/__init__.py
+++ b/processing/patch/__init__.py
@@ -25,7 +25,7 @@ _get_sentence_embeddings = apply._get_sentence_embeddings
 
 
 class PatchGenerator:
-    """Generate patch instructions and apply them to text."""
+    """Generate and apply patch instructions to chapter text."""
 
     async def generate_and_apply(
         self,
@@ -38,7 +38,26 @@ class PatchGenerator:
         already_patched_spans: list[tuple[int, int]] | None,
         validator: PatchValidationAgent,
     ) -> tuple[str, list[tuple[int, int]], TokenUsage | None]:
-        """Return revised text, updated spans, and token usage."""
+        """Generate patch instructions and apply them.
+
+        Args:
+            plot_outline: Outline of the overall plot for context.
+            original_text: The raw chapter text to be revised.
+            problems_to_fix: Issues detected during evaluation.
+            chapter_number: Current chapter index.
+            hybrid_context_for_revision: Context window from previous chapters.
+            chapter_plan: Optional list of scene details for planning.
+            already_patched_spans: Ranges that should be preserved.
+            validator: Agent responsible for validating proposed patches.
+
+        Returns:
+            A tuple containing the patched text, the spans in the revised text
+            that correspond to applied patches, and optional token usage data.
+
+        Side Effects:
+            Calls out to the LLM service for embeddings and patch generation and
+            logs progress via ``structlog``.
+        """
         sentence_embeddings = await _get_sentence_embeddings(original_text)
         patch_instructions, usage = await _generate_patch_instructions_logic(
             plot_outline,

--- a/processing/revision_manager.py
+++ b/processing/revision_manager.py
@@ -41,7 +41,34 @@ class RevisionManager:
         is_from_flawed_source: bool = False,
         already_patched_spans: list[tuple[int, int]] | None = None,
     ) -> tuple[tuple[str, str | None, list[tuple[int, int]]] | None, TokenUsage | None]:
-        """Revise a chapter draft based on evaluation feedback."""
+        """Revise a chapter draft based on evaluation feedback.
+
+        Args:
+            plot_outline: The overall plot outline for the novel.
+            character_profiles: Profiles of all major characters.
+            world_building: World building items grouped by category.
+            original_text: The initial chapter draft to revise.
+            chapter_number: Number of the chapter being revised.
+            evaluation_result: Structured feedback from the evaluator agent.
+            hybrid_context_for_revision: Context window for maintaining
+                continuity with previous chapters.
+            chapter_plan: Optional scene plan used when agentic planning is
+                enabled.
+            is_from_flawed_source: Whether the original text came from a flawed
+                generation process.
+            already_patched_spans: Spans previously protected from further
+                modification.
+
+        Returns:
+            A tuple containing either the revised text, the raw LLM output, and
+            updated spans, or ``None`` if revision failed. The second element of
+            the outer tuple is token usage information accumulated during the
+            process.
+
+        Side Effects:
+            Communicates with multiple agents and the LLM service and logs
+            progress throughout the revision process.
+        """
         if already_patched_spans is None:
             already_patched_spans = []
 


### PR DESCRIPTION
## Summary
- document `PatchGenerator.generate_and_apply`
- expand `validate_patch` in `PatchValidationAgent`
- describe `NoOpPatchValidator` behaviour
- document `RevisionManager.revise_chapter`

## Testing
- `ruff format processing/patch/__init__.py agents/patch_validation_agent.py processing/revision_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_685e34782904832fb06183e73c1fc386