### PR TITLE
Refactor patch locating logic

### DIFF
--- a/processing/patch/__init__.py
+++ b/processing/patch/__init__.py
@@ -22,6 +22,7 @@ _group_problems_for_patch_generation = instructions._group_problems_for_patch_ge
 _generate_patch_instructions_logic = instructions._generate_patch_instructions_logic
 _apply_patches_to_text = apply._apply_patches_to_text
 _get_sentence_embeddings = apply._get_sentence_embeddings
+locate_patch_targets = apply.locate_patch_targets
 
 
 class PatchGenerator:


### PR DESCRIPTION
## Summary
- extract `locate_patch_targets` helper for resolving patch spans
- adjust `_apply_patches_to_text` to rely on new helper
- expose helper in `processing.patch`
- test locating patch targets directly

## Testing
- `ruff check .`
- `ruff format --check .`
- `mypy .` *(fails: Argument "model_name" to "async_call_llm" ...)*
- `pytest tests/test_revision_patching.py::test_locate_patch_targets_direct tests/test_revision_patching.py::test_locate_patch_targets_semantic tests/test_revision_patching.py::test_patch_skipped_when_high_similarity -v` *(fails: Coverage failure: total of 7 is less than fail-under=85)*
- `pytest tests/ -v --cov=. --cov-report=term-missing` *(fails: Required test coverage of 85.0% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_685e3553beac832f90a4052fb7fb0fa3