### PR TITLE
Add patch validation score test

### DIFF
--- a/tests/test_patch_validation_agent.py
+++ b/tests/test_patch_validation_agent.py
@@ -1,0 +1,26 @@
+import pytest
+from agents.patch_validation_agent import PatchValidationAgent
+from config import settings
+from core.llm_interface import llm_service
+
+
+@pytest.mark.asyncio
+async def test_validation_rejects_below_threshold(monkeypatch):
+    async def fake_call(*_a, **_k):
+        return f"{settings.PATCH_VALIDATION_THRESHOLD - 1} low", None
+
+    monkeypatch.setattr(llm_service, "async_call_llm", fake_call)
+    agent = PatchValidationAgent()
+    ok, _ = await agent.validate_patch("ctx", {"replace_with": "x"}, [])
+    assert not ok
+
+
+@pytest.mark.asyncio
+async def test_validation_accepts_at_threshold(monkeypatch):
+    async def fake_call(*_a, **_k):
+        return f"{settings.PATCH_VALIDATION_THRESHOLD} ok", None
+
+    monkeypatch.setattr(llm_service, "async_call_llm", fake_call)
+    agent = PatchValidationAgent()
+    ok, _ = await agent.validate_patch("ctx", {"replace_with": "x"}, [])
+    assert ok


### PR DESCRIPTION
## Summary
- ensure low scores fail validation
- ensure threshold score passes validation

## Testing
- `ruff check . && ruff format --check .`
- `pytest tests/ -v --cov=. --cov-report=term-missing` *(fails: Required test coverage of 85.0% not reached)*
- `mypy .` *(fails: Found 99 errors in 32 files)*

------
https://chatgpt.com/codex/tasks/task_e_685e3ef142e4832f939b16f15aab3054