### PR TITLE
Implement LRU cache for sentence embeddings

### DIFF
--- a/config.py
+++ b/config.py
@@ -179,6 +179,7 @@ class SagaSettings(BaseSettings):
     SUMMARY_CACHE_SIZE: int = 32
     KG_TRIPLE_EXTRACTION_CACHE_SIZE: int = 16
     TOKENIZER_CACHE_SIZE: int = 10
+    SENTENCE_EMBEDDING_CACHE_SIZE: int = 32
 
     # Reranking Configuration
     ENABLE_RERANKING: bool = False


### PR DESCRIPTION
## Summary
- add `SENTENCE_EMBEDDING_CACHE_SIZE` config option
- implement `LRUDict` for caching sentence embeddings with eviction
- enforce cache limit in `_get_sentence_embeddings`
- test cache eviction when exceeding limit

## Testing
- `ruff check .`
- `ruff format --check .`
- `pytest tests/ -v --cov=. --cov-report=term-missing` *(fails: Required test coverage of 85% not reached)*
- `mypy .` *(fails: found 99 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685e40147c88832f95f124064357fa49