### PR TITLE
Fix token accounting when using dataclass usage info

### DIFF
--- a/orchestration/nana_orchestrator.py
+++ b/orchestration/nana_orchestrator.py
@@ -23,6 +23,7 @@ from chapter_generation import (
 )
 from config import settings
 from core.db_manager import neo4j_manager
+from core.usage import TokenUsage
 from data_access import (
     chapter_queries,
     character_queries,
@@ -114,7 +115,9 @@ class NANA_Orchestrator:
             run_start_time=self.run_start_time,
         )
 
-    def _accumulate_tokens(self, stage: str, usage_data: dict[str, int] | None) -> None:
+    def _accumulate_tokens(
+        self, stage: str, usage_data: dict[str, int] | TokenUsage | None
+    ) -> None:
         self.token_accountant.record_usage(stage, usage_data)
         self.total_tokens_generated_this_run = self.token_accountant.total
         self._update_rich_display()

--- a/tests/test_token_accountant_misc.py
+++ b/tests/test_token_accountant_misc.py
@@ -1,5 +1,6 @@
 import logging
 
+from core.usage import TokenUsage
 from orchestration.token_accountant import Stage, TokenAccountant
 
 
@@ -25,3 +26,13 @@ def test_token_accountant_add_invalid_usage(caplog):
     tracker.record_usage(Stage.DRAFTING.value, {"other": 1})
     assert tracker.total == 0
     assert any("missing" in record.message.lower() for record in caplog.records)
+
+
+def test_token_accountant_accepts_tokenusage(caplog):
+    caplog.set_level(logging.INFO)
+    tracker = TokenAccountant()
+    usage = TokenUsage(prompt_tokens=1, completion_tokens=4, total_tokens=5)
+    tracker.record_usage(Stage.DRAFTING, usage)
+    assert tracker.total == 4
+    assert tracker.get_stage_total(Stage.DRAFTING) == 4
+    assert any("tokens from" in record.message.lower() for record in caplog.records)


### PR DESCRIPTION
## Summary
- ensure `TokenAccountant.record_usage` handles `TokenUsage` objects
- pass `TokenUsage` through `_accumulate_tokens`
- test handling of `TokenUsage`

## Testing
- `ruff check . && ruff format --check .`
- `pytest tests/ -v --cov=. --cov-report=term-missing` *(fails: Required test coverage of 85.0% not reached)*
- `mypy .` *(fails: 100 errors in 33 files)*

------
https://chatgpt.com/codex/tasks/task_e_685e459f4f4c832f8a62a9664961fd86