### PR TITLE
Fix logging calls

### DIFF
--- a/reset_neo4j.py
+++ b/reset_neo4j.py
@@ -31,7 +31,7 @@ async def reset_neo4j_database_async(uri, user, password, confirm=False):
             "in the Neo4j database. This is a destructive operation. Continue? (y/N): "
         )
         if response.lower() not in ["y", "yes"]:
-            print("Operation cancelled.")
+            logger.info("Operation cancelled.")
             return False
 
     effective_uri = uri or settings.NEO4J_URI  # MODIFIED

--- a/tests/test_logging_mods.py
+++ b/tests/test_logging_mods.py
@@ -1,0 +1,58 @@
+import importlib
+import logging
+import logging as std_logging
+
+import pytest
+import reset_neo4j
+import utils.logging as logging_utils
+from config import settings
+
+
+@pytest.mark.asyncio
+async def test_reset_cancel_logs_info(monkeypatch, caplog):
+    caplog.set_level(logging.INFO)
+    root_logger = std_logging.getLogger()
+
+    # Configure structlog before reloading module so logger uses logging
+    logging_utils.structlog.configure(
+        logger_factory=logging_utils.structlog.stdlib.LoggerFactory()
+    )
+    importlib.reload(reset_neo4j)
+
+    logging_utils.setup_logging_nana()
+    root_logger.addHandler(caplog.handler)
+
+    monkeypatch.setattr("builtins.input", lambda *_a, **_k: "n")
+    result = await reset_neo4j.reset_neo4j_database_async(
+        None, None, None, confirm=False
+    )
+    assert result is False
+    assert any("Operation cancelled." in record.message for record in caplog.records)
+
+
+def test_setup_logging_file_error(monkeypatch, caplog):
+    caplog.set_level(logging.ERROR)
+    root_logger = std_logging.getLogger()
+
+    class Handlers(list):
+        def clear(self):
+            pass
+
+    root_logger.handlers = Handlers([caplog.handler])
+
+    logging_utils.structlog.configure(
+        logger_factory=logging_utils.structlog.stdlib.LoggerFactory()
+    )
+    importlib.reload(logging_utils)
+
+    def raise_handler(*_a, **_k):
+        raise OSError("fail")
+
+    monkeypatch.setattr(std_logging.handlers, "RotatingFileHandler", raise_handler)
+    monkeypatch.setattr(settings, "LOG_FILE", "temp.log")
+
+    logging_utils.setup_logging_nana()
+
+    assert any(
+        "Error setting up file logger" in record.message for record in caplog.records
+    )

--- a/utils/logging.py
+++ b/utils/logging.py
@@ -9,6 +9,8 @@ import os
 import structlog
 from config import settings
 
+logger = structlog.get_logger(__name__)
+
 try:
     from rich.logging import RichHandler
 
@@ -69,7 +71,7 @@ def setup_logging_nana() -> None:
             file_handler.setFormatter(file_formatter)
             root_logger.addHandler(file_handler)
         except Exception as e:  # pragma: no cover - path issues
-            print(f"Error setting up file logger: {e}")
+            logger.error("Error setting up file logger: %s", e)
 
     if RICH_AVAILABLE and settings.ENABLE_RICH_PROGRESS:
         console_handler = RichHandler(


### PR DESCRIPTION
## Summary
- switch legacy prints to `structlog` usage
- test log capture on failure cases

## Testing
- `ruff check .`
- `ruff format --check .`
- `pytest tests/test_logging_mods.py -v --cov=. --cov-report=term-missing`
- `pytest tests/ -v --cov=. --cov-report=term-missing` *(fails: Required test coverage of 85% not reached)*
- `mypy .` *(fails: 100 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685eb644a12c832f99c1a5fe3918be58