### PR TITLE
feat(cli): close llm service on shutdown

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ import asyncio
 
 import structlog
 from core.db_manager import neo4j_manager
+from core.llm_interface import llm_service
 from orchestration.nana_orchestrator import NANA_Orchestrator
 from utils.logging import setup_logging_nana
 
@@ -38,17 +39,22 @@ def main() -> None:
             async def _close_driver_main() -> None:
                 await neo4j_manager.close()
 
-            try:
-                loop = asyncio.get_running_loop()
-                if not loop.is_closed():
-                    loop.create_task(_close_driver_main())
-            except RuntimeError:
-                asyncio.run(_close_driver_main())
-            except Exception as e:
-                logger.warning(
-                    "Could not explicitly close driver from main: %s",
-                    e,
-                )
+        async def _close_llm_main() -> None:
+            await llm_service.aclose()
+
+        try:
+            loop = asyncio.get_running_loop()
+            if not loop.is_closed():
+                loop.create_task(_close_driver_main())
+                loop.create_task(_close_llm_main())
+        except RuntimeError:
+            asyncio.run(_close_driver_main())
+            asyncio.run(_close_llm_main())
+        except Exception as e:
+            logger.warning(
+                "Could not explicitly close driver from main: %s",
+                e,
+            )
 
 
 if __name__ == "__main__":

--- a/orchestration/nana_orchestrator.py
+++ b/orchestration/nana_orchestrator.py
@@ -23,6 +23,7 @@ from chapter_generation import (
 )
 from config import settings
 from core.db_manager import neo4j_manager
+from core.llm_interface import llm_service
 from core.usage import TokenUsage
 from data_access import (
     chapter_queries,
@@ -913,6 +914,7 @@ class NANA_Orchestrator:
             self._update_rich_display(step="Critical Error in Main Loop")
         finally:
             await self.display.stop()
+            await llm_service.aclose()
 
     async def run_ingestion_process(self, text_file: str) -> None:
         """Ingest existing text and populate the knowledge graph."""
@@ -942,4 +944,5 @@ class NANA_Orchestrator:
             )
         self.chapter_count = await chapter_queries.load_chapter_count_from_db()
         await self.display.stop()
+        await llm_service.aclose()
         logger.info("NANA: Ingestion process completed.")

--- a/tests/test_ingestion_healing.py
+++ b/tests/test_ingestion_healing.py
@@ -4,6 +4,7 @@ import config
 import pytest
 import utils
 from core.db_manager import neo4j_manager
+from core.llm_interface import llm_service
 from data_access import plot_queries
 from orchestration.nana_orchestrator import NANA_Orchestrator
 
@@ -35,6 +36,8 @@ async def test_ingestion_triggers_healing(monkeypatch, tmp_path):
 
     monkeypatch.setattr(orch.display, "start", lambda: None)
     monkeypatch.setattr(orch.display, "stop", AsyncMock())
+    llm_close = AsyncMock()
+    monkeypatch.setattr(llm_service, "aclose", llm_close)
     monkeypatch.setattr(neo4j_manager, "connect", AsyncMock())
     monkeypatch.setattr(neo4j_manager, "create_db_schema", AsyncMock())
     monkeypatch.setattr(neo4j_manager, "close", AsyncMock())
@@ -52,3 +55,4 @@ async def test_ingestion_triggers_healing(monkeypatch, tmp_path):
     await orch.run_ingestion_process(str(text_file))
 
     assert heal.call_count == 3
+    llm_close.assert_awaited_once()

--- a/tests/test_main_cleanup.py
+++ b/tests/test_main_cleanup.py
@@ -1,0 +1,26 @@
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import main
+from core.llm_interface import llm_service
+
+
+def test_main_invokes_llm_aclose(monkeypatch):
+    orchestrator = SimpleNamespace(
+        run_novel_generation_loop=AsyncMock(),
+        run_ingestion_process=AsyncMock(),
+    )
+
+    monkeypatch.setattr(main, "NANA_Orchestrator", lambda: orchestrator)
+    monkeypatch.setattr(sys, "argv", ["prog"])
+
+    monkeypatch.setattr(main.neo4j_manager, "driver", object())
+    monkeypatch.setattr(main.neo4j_manager, "close", AsyncMock())
+
+    llm_close = AsyncMock()
+    monkeypatch.setattr(llm_service, "aclose", llm_close)
+
+    main.main()
+
+    llm_close.assert_awaited_once()

--- a/tests/test_novel_generation_dynamic.py
+++ b/tests/test_novel_generation_dynamic.py
@@ -4,6 +4,7 @@ import config
 import pytest
 import utils
 from core.db_manager import neo4j_manager
+from core.llm_interface import llm_service
 from data_access import chapter_queries
 from initialization.models import PlotOutline
 from orchestration.nana_orchestrator import NANA_Orchestrator
@@ -54,9 +55,12 @@ async def test_dynamic_chapter_adjustment(monkeypatch):
     )
     monkeypatch.setattr(orch.display, "start", lambda: None)
     monkeypatch.setattr(orch.display, "stop", AsyncMock())
+    llm_close = AsyncMock()
+    monkeypatch.setattr(llm_service, "aclose", llm_close)
     monkeypatch.setattr(orch, "_validate_critical_configs", lambda: True)
 
     await orch.run_novel_generation_loop()
 
     assert calls == [1, 2, 3]
     assert orch.chapter_count == 3
+    llm_close.assert_awaited_once()


### PR DESCRIPTION
## Summary
- ensure LLM client closes in `main.main`
- await `llm_service.aclose()` after orchestrator runs
- check that shutdown occurs in tests

## Testing
- `ruff check .`
- `mypy .` *(fails: incompatible types and other errors)*
- `pytest tests/ -v --cov=. --cov-report=term-missing` *(fails: coverage 45% < 85%)*

------
https://chatgpt.com/codex/tasks/task_e_685eb955dcc0832fb2963e9f78058e6c