### PR TITLE
Add pytest-cov with version pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,5 +21,5 @@ rapidfuzz>=3.6,<4
 # Development & Testing Dependencies
 flake8==7.0.0
 pytest==8.3.5
-pytest-cov
+pytest-cov>=6,<7
 pytest-asyncio


### PR DESCRIPTION
## Summary
- pin pytest-cov major version for dev usage

## Testing
- `ruff check . && ruff format --check .`
- `pytest tests/ -v --cov=. --cov-report=term-missing` *(fails: Required test coverage of 85% not reached)*
- `mypy .` *(fails: found 99 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685ebe2a1b00832faf66c51c695a2002