### PR TITLE
Fix param building for KG queries

### DIFF
--- a/data_access/kg_queries.py
+++ b/data_access/kg_queries.py
@@ -394,8 +394,12 @@ async def get_chapter_context_for_entity(
     match_clause = (
         "MATCH (e {id: $id_param})" if entity_id else "MATCH (e {name: $name_param})"
     )
-    params = {"id_param": entity_id} if entity_id else {"name_param": entity_name}
-    params = {k: v for k, v in params.items() if v is not None}
+
+    params: dict[str, str] = {}
+    if entity_id is not None:
+        params["id_param"] = entity_id
+    elif entity_name is not None:
+        params["name_param"] = entity_name
 
     query = f"""
     {match_clause}


### PR DESCRIPTION
## Summary
- only add param keys when values are provided

## Testing
- `ruff check . && ruff format --check .`
- `pytest tests/ -v --cov=. --cov-report=term-missing` *(fails: Coverage failure)*
- `mypy .` *(fails: found 98 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685ec3e845ac832fa23025fc603e15e3