### PR TITLE
Fix fallback RichHandler setup

### DIFF
--- a/utils/logging.py
+++ b/utils/logging.py
@@ -9,20 +9,29 @@ import os
 import structlog
 from config import settings
 
+_RichHandler: type[logging.Handler]
+
 logger = structlog.get_logger(__name__)
 
 try:
-    from rich.logging import RichHandler
+    import rich.logging as rich_logging
+
+    _RichHandler = rich_logging.RichHandler
 
     RICH_AVAILABLE = True
 except Exception:  # pragma: no cover - fallback when Rich is missing
     RICH_AVAILABLE = False
 
     class _FallbackRichHandler(logging.Handler):
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            super().__init__()
+
         def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover
             logging.getLogger(__name__).handle(record)
 
-    RichHandler = _FallbackRichHandler
+    _RichHandler = _FallbackRichHandler
+
+RichHandler = _RichHandler
 
 
 __all__ = ["setup_logging_nana"]


### PR DESCRIPTION
## Summary
- handle Rich logging import cleanly
- keep fallback handler around for when Rich is absent

## Testing
- `ruff check utils/logging.py`
- `ruff check .`
- `ruff format --check .`
- `pytest tests/ -v --cov=. --cov-report=term-missing` *(fails: Required test coverage of 85.0% not reached)*
- `mypy utils/logging.py` *(fails: various unrelated type errors)*
- `mypy .` *(fails: many errors, but no longer flags no-redef for logging)*

------
https://chatgpt.com/codex/tasks/task_e_685ec4ee1e5c832fb722280ff2abd3f6