### PR TITLE
Implement orchestrator shutdown handling

### DIFF
--- a/orchestration/nana_orchestrator.py
+++ b/orchestration/nana_orchestrator.py
@@ -914,7 +914,7 @@ class NANA_Orchestrator:
             self._update_rich_display(step="Critical Error in Main Loop")
         finally:
             await self.display.stop()
-            await llm_service.aclose()
+            await self.shutdown()
 
     async def run_ingestion_process(self, text_file: str) -> None:
         """Ingest existing text and populate the knowledge graph."""
@@ -942,7 +942,14 @@ class NANA_Orchestrator:
             logger.warning(
                 "Neo4j driver not initialized. Skipping knowledge cache refresh."
             )
+
         self.chapter_count = await chapter_queries.load_chapter_count_from_db()
         await self.display.stop()
-        await llm_service.aclose()
+        await self.shutdown()
         logger.info("NANA: Ingestion process completed.")
+
+    async def shutdown(self) -> None:
+        """Close the Neo4j driver and the LLM service."""
+        if neo4j_manager.driver is not None:
+            await neo4j_manager.close()
+        await llm_service.aclose()

--- a/tests/test_main_cleanup.py
+++ b/tests/test_main_cleanup.py
@@ -3,24 +3,18 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import main
-from core.llm_interface import llm_service
 
 
-def test_main_invokes_llm_aclose(monkeypatch):
+def test_main_invokes_shutdown(monkeypatch):
     orchestrator = SimpleNamespace(
         run_novel_generation_loop=AsyncMock(),
         run_ingestion_process=AsyncMock(),
+        shutdown=AsyncMock(),
     )
 
     monkeypatch.setattr(main, "NANA_Orchestrator", lambda: orchestrator)
     monkeypatch.setattr(sys, "argv", ["prog"])
 
-    monkeypatch.setattr(main.neo4j_manager, "driver", object())
-    monkeypatch.setattr(main.neo4j_manager, "close", AsyncMock())
-
-    llm_close = AsyncMock()
-    monkeypatch.setattr(llm_service, "aclose", llm_close)
-
     main.main()
 
-    llm_close.assert_awaited_once()
+    orchestrator.shutdown.assert_awaited_once()


### PR DESCRIPTION
## Summary
- add `shutdown` method to `NANA_Orchestrator`
- invoke `shutdown` after novel generation and ingestion
- update main entry point to use new shutdown logic
- revise main cleanup test

## Testing
- `ruff check . && ruff format --check .`
- `pytest tests/ -v --cov=. --cov-report=term-missing` *(fails: Coverage failure: total of 46 is less than fail-under=85)*
- `mypy .` *(fails: 96 errors in 30 files)*

------
https://chatgpt.com/codex/tasks/task_e_685ec8068404832fb4d881b9bb6a1714