### PR TITLE
Add docstrings for DB utilities

### DIFF
--- a/data_access/character_queries.py
+++ b/data_access/character_queries.py
@@ -67,6 +67,8 @@ async def sync_characters(
 
 
 async def sync_full_state_from_object_to_db(profiles_data: dict[str, Any]) -> bool:
+    """Persist the full set of character profiles to Neo4j."""
+
     logger.info("Synchronizing character profiles to Neo4j (non-destructive)...")
 
     novel_id_param = settings.MAIN_NOVEL_INFO_NODE_ID  # MODIFIED
@@ -437,6 +439,8 @@ async def get_all_character_names() -> list[str]:
 
 
 async def get_character_profiles_from_db() -> dict[str, CharacterProfile]:
+    """Load all character profiles from Neo4j."""
+
     logger.info("Loading decomposed character profiles from Neo4j...")
     profiles_data: dict[str, CharacterProfile] = {}
 
@@ -538,6 +542,16 @@ async def get_character_profiles_from_db() -> dict[str, CharacterProfile]:
 async def get_character_info_for_snippet_from_db(
     char_name: str, chapter_limit: int
 ) -> dict[str, Any] | None:
+    """Return character details with history up to ``chapter_limit``.
+
+    Args:
+        char_name: Name of the character to fetch.
+        chapter_limit: Highest chapter number to consider when collecting data.
+
+    Returns:
+        A dictionary of character info or ``None`` if not found.
+    """
+
     canonical_name = resolve_character_name(char_name)
     query = """
     MATCH (c:Character:Entity {name: $char_name_param})

--- a/data_access/kg_queries.py
+++ b/data_access/kg_queries.py
@@ -113,6 +113,8 @@ async def add_kg_triples_batch_to_db(
     chapter_number: int,
     is_from_flawed_draft: bool,
 ):
+    """Insert a batch of knowledge graph triples into Neo4j."""
+
     if not structured_triples_data:
         logger.info("Neo4j: add_kg_triples_batch_to_db: No structured triples to add.")
         return
@@ -248,6 +250,19 @@ async def query_kg_from_db(
     include_provisional: bool = True,
     limit_results: int | None = None,
 ) -> list[dict[str, Any]]:
+    """Query dynamic relationships from the graph with optional filters.
+
+    Args:
+        subject: Subject entity name to match.
+        predicate: Relationship type to match.
+        obj_val: Object entity or literal value to match.
+        chapter_limit: Only consider relationships up to this chapter.
+        include_provisional: Include provisional relationships when ``True``.
+        limit_results: Maximum number of records to return.
+
+    Returns:
+        A list of matching relationship dictionaries.
+    """
     conditions = []
     parameters: dict[str, str] = {}
     match_clause = "MATCH (s:Entity)-[r:DYNAMIC_REL]->(o) "
@@ -322,6 +337,8 @@ async def get_most_recent_value_from_db(
     chapter_limit: int | None = None,
     include_provisional: bool = False,
 ) -> Any | None:
+    """Get the newest relationship value for ``subject`` and ``predicate``."""
+
     if not subject.strip() or not predicate.strip():
         logger.warning(
             f"Neo4j: get_most_recent_value_from_db: empty subject or predicate. S='{subject}', P='{predicate}'"

--- a/data_access/plot_queries.py
+++ b/data_access/plot_queries.py
@@ -25,6 +25,8 @@ async def ensure_novel_info() -> None:
 
 
 async def save_plot_outline_to_db(plot_data: dict[str, Any]) -> bool:
+    """Persist the plot outline structure to Neo4j."""
+
     logger.info("Synchronizing plot outline to Neo4j (non-destructive)...")
     if not plot_data:
         logger.warning(
@@ -182,6 +184,8 @@ async def save_plot_outline_to_db(plot_data: dict[str, Any]) -> bool:
 
 
 async def get_plot_outline_from_db() -> dict[str, Any]:
+    """Retrieve the plot outline and associated plot points from Neo4j."""
+
     logger.info("Loading decomposed plot outline from Neo4j...")
     novel_id = settings.MAIN_NOVEL_INFO_NODE_ID  # MODIFIED
     plot_data: dict[str, Any] = {}

--- a/data_access/world_queries.py
+++ b/data_access/world_queries.py
@@ -96,6 +96,8 @@ async def sync_world_items(
 
 
 async def sync_full_state_from_object_to_db(world_data: dict[str, Any]) -> bool:
+    """Persist the entire world-building state to Neo4j."""
+
     logger.info("Synchronizing world building data to Neo4j (non-destructive)...")
 
     novel_id_param = settings.MAIN_NOVEL_INFO_NODE_ID  # MODIFIED
@@ -568,6 +570,8 @@ async def get_all_world_item_ids_by_category() -> dict[str, list[str]]:
 
 
 async def get_world_building_from_db() -> dict[str, dict[str, WorldItem]]:
+    """Load all world elements grouped by category from Neo4j."""
+
     logger.info("Loading decomposed world building data from Neo4j...")
     world_data: dict[str, dict[str, WorldItem]] = {}
     wc_id_param = settings.MAIN_WORLD_CONTAINER_NODE_ID  # MODIFIED
@@ -723,6 +727,8 @@ async def get_world_building_from_db() -> dict[str, dict[str, WorldItem]]:
 async def get_world_elements_for_snippet_from_db(
     category: str, chapter_limit: int, item_limit: int
 ) -> list[dict[str, Any]]:
+    """Return a subset of world elements for prompt context."""
+
     query = f"""
     MATCH (we:WorldElement:Entity {{category: $category_param}})
     WHERE (we.{KG_NODE_CREATED_CHAPTER} IS NULL OR we.{KG_NODE_CREATED_CHAPTER} <= $chapter_limit_param)


### PR DESCRIPTION
## Summary
- document database helper functions across the `data_access` module
- clarify world data helpers with missing docstrings

## Testing
- `ruff check .`
- `ruff format --check .`
- `mypy .` *(fails: 96 errors)*
- `pytest tests/ -v --cov=. --cov-report=term-missing` *(fails: coverage below 85%)*

------
https://chatgpt.com/codex/tasks/task_e_685ecb0c16d0832f841cdec8636c916c