### PR TITLE
Fix world bootstrap validation error

### DIFF
--- a/initialization/bootstrappers/world_bootstrapper.py
+++ b/initialization/bootstrappers/world_bootstrapper.py
@@ -46,8 +46,6 @@ def create_default_world() -> WorldBuilding:
                 },
             )
         },
-        "is_default": True,  # type: ignore
-        "source": "default_fallback",  # type: ignore
     }
 
     standard_categories = [

--- a/tests/test_world_bootstrapper_default.py
+++ b/tests/test_world_bootstrapper_default.py
@@ -1,0 +1,9 @@
+from initialization.bootstrappers.world_bootstrapper import create_default_world
+
+
+def test_create_default_world_excludes_metadata_in_data():
+    wb = create_default_world()
+    assert "is_default" not in wb.data
+    assert "source" not in wb.data
+    assert wb.is_default is True
+    assert wb.source == "default_fallback"


### PR DESCRIPTION
## Summary
- correct default world data structure so metadata keys aren't nested in `data`
- test that `create_default_world` stores metadata separately

## Testing
- `ruff check . && ruff format --check .`
- `pytest tests/ -v --cov=. --cov-report=term-missing` *(fails: Required test coverage of 85% not reached)*
- `mypy .` *(fails: found errors)*

------
https://chatgpt.com/codex/tasks/task_e_685ed2bc3670832fafef15450035ba88