### PR TITLE
Fix repeated chapters due to context order

### DIFF
--- a/chapter_generation/context_service.py
+++ b/chapter_generation/context_service.py
@@ -161,7 +161,7 @@ class ContextService:
                         break
 
         if total_tokens_accumulated >= max_semantic_tokens:
-            final_semantic_context = "\n".join(reversed(immediate_parts)).strip()
+            final_semantic_context = "\n".join(immediate_parts).strip()
             final_tokens_count = count_tokens(
                 final_semantic_context, settings.DRAFTING_MODEL
             )
@@ -233,7 +233,7 @@ class ContextService:
                                 total_tokens_accumulated += remaining_tokens
                             break
             final_semantic_context = "\n".join(
-                immediate_parts + list(reversed(context_parts_list))
+                immediate_parts + context_parts_list
             ).strip()
             final_tokens_count = count_tokens(
                 final_semantic_context, settings.DRAFTING_MODEL
@@ -327,9 +327,7 @@ class ContextService:
                     score_str,
                 )
 
-        final_semantic_context = "\n".join(
-            list(reversed(immediate_parts)) + context_parts_list
-        ).strip()
+        final_semantic_context = "\n".join(immediate_parts + context_parts_list).strip()
         final_tokens_count = count_tokens(
             final_semantic_context, settings.DRAFTING_MODEL
         )

--- a/tests/test_context_generator.py
+++ b/tests/test_context_generator.py
@@ -41,8 +41,8 @@ async def test_immediate_context_added(monkeypatch):
 
     service = ContextService(chapter_queries, llm_service)
     ctx = await service.get_semantic_context({}, 4)
-    assert ctx.startswith("[Immediate Context from Chapter 3")
-    assert ctx.index("[Immediate Context from Chapter 2") < ctx.index(
+    assert ctx.startswith("[Immediate Context from Chapter 2")
+    assert ctx.index("[Immediate Context from Chapter 3") < ctx.index(
         "Semantic Context from Chapter 1"
     )
 


### PR DESCRIPTION
## Summary
- correct semantic context ordering to put older chapters first
- update tests for new ordering

## Testing
- `ruff check .`
- `ruff format --check .`
- `pytest tests/ -v --cov=. --cov-report=term-missing` *(fails: Required test coverage of 85.0% not reached)*
- `mypy .` *(fails: 96 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685f16d30a08832fb5c594a6a0397ac8