### PR TITLE
[CORE] implement context orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ SAGA's NANA engine orchestrates a sophisticated pipeline for novel generation:
     *   **(A) Prerequisites (`orchestration.chapter_flow`):**
         *   Retrieves the current **Plot Point Focus** for the chapter.
         *   **Planning (if enabled):** The `PlannerAgent` creates a detailed scene-by-scene plan.
-        *   **Context Generation:** `chapter_generation.context_service.ContextService` assembles a "hybrid context" string by:
+        *   **Context Generation:** `chapter_generation.context_orchestrator.ContextOrchestrator` assembles a "hybrid context" string by:
             *   Querying Neo4j for semantically similar past chapter summaries/text snippets (vector search).
             *   Fetching key reliable facts from the Knowledge Graph via `prompt_data_getters`.
     *   **(B) Drafting:**

--- a/chapter_generation/__init__.py
+++ b/chapter_generation/__init__.py
@@ -1,5 +1,6 @@
 """Utilities for orchestrating chapter generation steps."""
 
+from .context_orchestrator import ContextOrchestrator, ContextRequest
 from .context_service import ContextService
 from .drafting_service import DraftingService, DraftResult
 from .evaluation_service import EvaluationCycleResult, EvaluationService
@@ -10,6 +11,8 @@ from .revision_service import RevisionResult, RevisionService
 __all__ = [
     "PrerequisitesService",
     "PrerequisiteData",
+    "ContextOrchestrator",
+    "ContextRequest",
     "DraftingService",
     "DraftResult",
     "EvaluationService",

--- a/chapter_generation/context_orchestrator.py
+++ b/chapter_generation/context_orchestrator.py
@@ -1,0 +1,124 @@
+# chapter_generation/context_orchestrator.py
+"""Orchestrates context generation from multiple providers."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Iterable
+from typing import Any
+
+import structlog
+from config import settings
+from core.llm_interface import count_tokens, truncate_text_by_tokens
+
+from models.agent_models import SceneDetail
+
+from .context_providers import ContextChunk, ContextProvider, ContextRequest
+
+logger = structlog.get_logger(__name__)
+
+
+class TTLCache:
+    """Simple TTL-based LRU cache."""
+
+    def __init__(self, maxsize: int, ttl: float) -> None:
+        self.maxsize = maxsize
+        self.ttl = ttl
+        self._data: dict[tuple, tuple[float, str]] = {}
+
+    def get(self, key: tuple) -> str | None:
+        item = self._data.get(key)
+        if not item:
+            return None
+        ts, value = item
+        if time.time() - ts > self.ttl:
+            del self._data[key]
+            return None
+        return value
+
+    def set(self, key: tuple, value: str) -> None:
+        if len(self._data) >= self.maxsize:
+            oldest = sorted(self._data.items(), key=lambda x: x[1][0])[0][0]
+            del self._data[oldest]
+        self._data[key] = (time.time(), value)
+
+
+class ContextOrchestrator:
+    """Gather and merge context from configured providers."""
+
+    def __init__(self, providers: Iterable[ContextProvider]) -> None:
+        self.providers = list(providers)
+        self.cache = TTLCache(settings.CONTEXT_CACHE_SIZE, settings.CONTEXT_CACHE_TTL)
+
+    async def build_context(self, request: ContextRequest) -> str:
+        """Return an ordered context string for the request."""
+        cache_key = (
+            request.chapter_number,
+            request.plot_focus,
+            tuple(sorted(request.agent_hints.items())) if request.agent_hints else None,
+        )
+        cached = self.cache.get(cache_key)
+        if cached:
+            logger.debug("Context cache hit", key=cache_key)
+            return cached
+
+        tasks = [p.get_context(request) for p in self.providers]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        chunks: list[ContextChunk] = []
+        for res in results:
+            if isinstance(res, ContextChunk):
+                chunks.append(res)
+            else:
+                logger.warning("Context provider error", error=res)
+
+        merged: list[str] = []
+        token_total = 0
+        for chunk in chunks:
+            if not chunk.text:
+                continue
+            prefix = f"[{chunk.source}]\n"
+            part = prefix + chunk.text
+            tokens = count_tokens(part, settings.DRAFTING_MODEL)
+            if token_total + tokens > settings.MAX_CONTEXT_TOKENS:
+                remaining = settings.MAX_CONTEXT_TOKENS - token_total
+                if remaining <= 0:
+                    break
+                part = truncate_text_by_tokens(part, settings.DRAFTING_MODEL, remaining)
+                merged.append(part)
+                token_total += remaining
+                break
+            merged.append(part)
+            token_total += tokens
+
+        final_context = "\n---\n".join(merged)
+        self.cache.set(cache_key, final_context)
+        logger.info("Built context", tokens=token_total)
+        return final_context
+
+    async def build_hybrid_context(
+        self,
+        agent_or_props: Any,
+        current_chapter_number: int,
+        chapter_plan: list[SceneDetail] | None,
+    ) -> str:
+        """Backward compatible wrapper for build_context."""
+        if isinstance(agent_or_props, dict):
+            plot_outline = agent_or_props.get(
+                "plot_outline_full", agent_or_props.get("plot_outline", {})
+            )
+            plot_focus = None
+        else:
+            plot_outline = getattr(
+                agent_or_props, "plot_outline_full", None
+            ) or getattr(agent_or_props, "plot_outline", {})
+            plot_focus = getattr(agent_or_props, "plot_point_focus", None)
+
+        request = ContextRequest(
+            chapter_number=current_chapter_number,
+            plot_focus=plot_focus,
+            plot_outline=plot_outline,
+            chapter_plan=chapter_plan,
+        )
+        return await self.build_context(request)

--- a/chapter_generation/context_providers.py
+++ b/chapter_generation/context_providers.py
@@ -1,0 +1,119 @@
+# chapter_generation/context_providers.py
+"""Context provider classes for assembling chapter context."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import structlog
+from core.llm_interface import count_tokens
+
+from models.agent_models import SceneDetail
+
+logger = structlog.get_logger(__name__)
+
+
+@dataclass
+class ContextRequest:
+    """Parameters describing the desired context."""
+
+    chapter_number: int
+    plot_focus: str | None
+    plot_outline: dict[str, Any]
+    chapter_plan: list[SceneDetail] | None = None
+    agent_hints: dict[str, Any] | None = None
+
+
+@dataclass
+class ContextChunk:
+    """A chunk of context returned by a provider."""
+
+    text: str
+    tokens: int
+    provenance: dict[str, Any]
+    source: str
+
+
+class ContextProvider:
+    """Base interface for all context providers."""
+
+    source: str = "base"
+
+    async def get_context(self, request: ContextRequest) -> ContextChunk:
+        """Return context for the given request."""
+        raise NotImplementedError
+
+
+class SemanticHistoryProvider(ContextProvider):
+    """Fetch context from previous chapters via vector search."""
+
+    source = "semantic_history"
+
+    def __init__(
+        self,
+        chapter_queries_module: Any | None = None,
+        llm_service_instance: Any | None = None,
+    ) -> None:
+        from core.llm_interface import llm_service as default_llm_service
+        from data_access import chapter_queries as default_chapter_queries
+
+        self.chapter_queries = chapter_queries_module or default_chapter_queries
+        self.llm_service = llm_service_instance or default_llm_service
+
+    async def get_context(self, request: ContextRequest) -> ContextChunk:
+        from chapter_generation.context_service import ContextService
+
+        service = ContextService(self.chapter_queries, self.llm_service)
+        text = await service.get_semantic_context(
+            request.plot_outline, request.chapter_number
+        )
+        tokens = count_tokens(text, "dummy")
+        return ContextChunk(text=text, tokens=tokens, provenance={}, source=self.source)
+
+
+class KGFactProvider(ContextProvider):
+    """Retrieve key facts from the knowledge graph."""
+
+    source = "kg_facts"
+
+    async def get_context(self, request: ContextRequest) -> ContextChunk:
+        from prompt_data_getters import get_reliable_kg_facts_for_drafting_prompt
+
+        text = await get_reliable_kg_facts_for_drafting_prompt(
+            request.plot_outline, request.chapter_number, request.chapter_plan
+        )
+        tokens = count_tokens(text, "dummy")
+        return ContextChunk(text=text, tokens=tokens, provenance={}, source=self.source)
+
+
+class PlanProvider(ContextProvider):
+    """Provide the chapter scene plan."""
+
+    source = "scene_plan"
+
+    async def get_context(self, request: ContextRequest) -> ContextChunk:
+        plan = request.chapter_plan or []
+        lines = []
+        for scene in plan:
+            summary = scene.get("summary")
+            if summary:
+                lines.append(f"- {summary}")
+        text = "\n".join(lines)
+        tokens = count_tokens(text, "dummy")
+        return ContextChunk(text=text, tokens=tokens, provenance={}, source=self.source)
+
+
+class UserNoteProvider(ContextProvider):
+    """Include user provided notes if any."""
+
+    source = "user_notes"
+
+    async def get_context(self, request: ContextRequest) -> ContextChunk:
+        notes = ""
+        if request.agent_hints:
+            notes = request.agent_hints.get("user_notes", "")
+        tokens = count_tokens(notes, "dummy")
+        return ContextChunk(
+            text=notes, tokens=tokens, provenance={}, source=self.source
+        )

--- a/config.py
+++ b/config.py
@@ -184,6 +184,14 @@ class SagaSettings(BaseSettings):
 
     # Reranking Configuration
     ENABLE_RERANKING: bool = False
+    CONTEXT_CACHE_SIZE: int = 16
+    CONTEXT_CACHE_TTL: float = 600.0
+    CONTEXT_PROVIDERS: list[str] = [
+        "chapter_generation.context_providers.SemanticHistoryProvider",
+        "chapter_generation.context_providers.KGFactProvider",
+        "chapter_generation.context_providers.PlanProvider",
+        "chapter_generation.context_providers.UserNoteProvider",
+    ]
     RERANKER_CANDIDATE_COUNT: int = 15
 
     # Agentic Planning & Prompt Context Snippets

--- a/processing/context_generator.py
+++ b/processing/context_generator.py
@@ -1,21 +1,38 @@
 from __future__ import annotations
 
+import importlib
 from typing import Any
 
-from chapter_generation.context_service import ContextService
+from chapter_generation import ContextOrchestrator, ContextRequest
+from config import settings
 
 from models import SceneDetail
 
-context_service = ContextService()
+provider_instances = []
+for dotted in settings.CONTEXT_PROVIDERS:
+    module_name, class_name = dotted.rsplit(".", 1)
+    module = importlib.import_module(module_name)
+    cls = getattr(module, class_name)
+    provider_instances.append(cls())
+context_service = ContextOrchestrator(provider_instances)
 
 
 async def _generate_semantic_chapter_context_logic(
     agent_or_props: Any, current_chapter_number: int
 ) -> str:
-    """Backward compatible wrapper for ContextService.get_semantic_context."""
-    return await context_service.get_semantic_context(
-        agent_or_props, current_chapter_number
+    """Generate semantic context via the orchestrator."""
+    outline = (
+        agent_or_props.get("plot_outline_full", agent_or_props.get("plot_outline", {}))
+        if isinstance(agent_or_props, dict)
+        else getattr(agent_or_props, "plot_outline_full", None)
+        or getattr(agent_or_props, "plot_outline", {})
     )
+    request = ContextRequest(
+        chapter_number=current_chapter_number,
+        plot_focus=None,
+        plot_outline=outline,
+    )
+    return await context_service.build_context(request)
 
 
 async def generate_hybrid_chapter_context_logic(
@@ -23,7 +40,17 @@ async def generate_hybrid_chapter_context_logic(
     current_chapter_number: int,
     chapter_plan: list[SceneDetail] | None,
 ) -> str:
-    """Backward compatible wrapper for ContextService.build_hybrid_context."""
-    return await context_service.build_hybrid_context(
-        agent_or_props, current_chapter_number, chapter_plan
+    """Generate full context via the orchestrator."""
+    outline = (
+        agent_or_props.get("plot_outline_full", agent_or_props.get("plot_outline", {}))
+        if isinstance(agent_or_props, dict)
+        else getattr(agent_or_props, "plot_outline_full", None)
+        or getattr(agent_or_props, "plot_outline", {})
     )
+    request = ContextRequest(
+        chapter_number=current_chapter_number,
+        plot_focus=None,
+        plot_outline=outline,
+        chapter_plan=chapter_plan,
+    )
+    return await context_service.build_context(request)

--- a/tests/test_context_orchestrator.py
+++ b/tests/test_context_orchestrator.py
@@ -1,0 +1,27 @@
+import pytest
+from chapter_generation.context_orchestrator import ContextOrchestrator, ContextRequest
+from chapter_generation.context_providers import ContextChunk, ContextProvider
+from config import settings
+
+
+class DummyProvider(ContextProvider):
+    def __init__(self, text: str, source: str) -> None:
+        self.text = text
+        self.source = source
+
+    async def get_context(self, request: ContextRequest) -> ContextChunk:
+        return ContextChunk(
+            text=self.text, tokens=len(self.text), provenance={}, source=self.source
+        )
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_truncates(monkeypatch):
+    monkeypatch.setattr(settings, "MAX_CONTEXT_TOKENS", 5)
+    orch = ContextOrchestrator(
+        [DummyProvider("abc", "A"), DummyProvider("defghij", "B")]
+    )
+    req = ContextRequest(1, None, {})
+    out = await orch.build_context(req)
+    assert "A" in out
+    assert "B" not in out or "defghij" not in out

--- a/tests/test_context_providers.py
+++ b/tests/test_context_providers.py
@@ -1,0 +1,37 @@
+import pytest
+from chapter_generation.context_providers import (
+    ContextRequest,
+    KGFactProvider,
+    PlanProvider,
+    UserNoteProvider,
+)
+
+
+@pytest.mark.asyncio
+async def test_plan_provider_basic():
+    provider = PlanProvider()
+    request = ContextRequest(1, None, {}, chapter_plan=[{"summary": "A"}])
+    chunk = await provider.get_context(request)
+    assert "A" in chunk.text
+
+
+@pytest.mark.asyncio
+async def test_user_note_provider():
+    provider = UserNoteProvider()
+    request = ContextRequest(1, None, {}, agent_hints={"user_notes": "note"})
+    chunk = await provider.get_context(request)
+    assert chunk.text == "note"
+
+
+@pytest.mark.asyncio
+async def test_kg_fact_provider(monkeypatch):
+    async def fake_get(*args, **kwargs):
+        return "fact"
+
+    monkeypatch.setattr(
+        "prompt_data_getters.get_reliable_kg_facts_for_drafting_prompt", fake_get
+    )
+    provider = KGFactProvider()
+    request = ContextRequest(2, None, {})
+    chunk = await provider.get_context(request)
+    assert chunk.text == "fact"


### PR DESCRIPTION
## Summary
- add new context provider framework with providers for semantic history, KG facts, plans and user notes
- implement ContextOrchestrator with simple caching
- wire orchestrator into NANA orchestrator and context generator
- update configuration for pluggable context providers
- add unit tests for providers and orchestrator
- update docs to reference ContextOrchestrator

## Agent Changes
- NANA orchestrator now builds context via `ContextOrchestrator`

## Database Changes
- none

## Configuration Changes
- `CONTEXT_CACHE_SIZE`, `CONTEXT_CACHE_TTL`, `CONTEXT_PROVIDERS`

## Testing Done
- `ruff check .`
- `mypy .` *(fails: 102 errors)*
- `pytest -v --cov=.` *(fails: coverage 48.06%)*

------
https://chatgpt.com/codex/tasks/task_e_685f3e69bfcc832faeccc058ebc44fdd