### PR TITLE
[ORCHESTRATION] prefetch next chapter context

### DIFF
--- a/tests/test_orchestrator_private_methods.py
+++ b/tests/test_orchestrator_private_methods.py
@@ -22,6 +22,13 @@ def orchestrator(monkeypatch):
     monkeypatch.setattr(utils, "load_spacy_model_if_needed", lambda: None)
     orch = NANA_Orchestrator()
     monkeypatch.setattr(orch, "_update_rich_display", lambda *a, **k: None)
+    monkeypatch.setattr(orch, "refresh_plot_outline", AsyncMock())
+    monkeypatch.setattr(orch, "refresh_knowledge_cache", AsyncMock())
+    monkeypatch.setattr(
+        orch.context_service,
+        "build_hybrid_context",
+        AsyncMock(return_value="ctx"),
+    )
     return orch
 
 


### PR DESCRIPTION
## Summary
- extend `NANA_Orchestrator` with `next_chapter_context`
- build initial context after initial setup
- reuse prebuilt context when preparing a chapter
- prefetch context for the upcoming chapter after finalizing one
- update tests for new refresh and context build calls

## Testing Done
- `ruff check . && ruff format . && mypy .`
- `pytest -v --cov=. # fails (coverage < 85%)`


------
https://chatgpt.com/codex/tasks/task_e_685f4bb03fd0832faa05782d1873a353