### PR TITLE
[PROCESSING] add evaluation pipeline and repetition analyzer

### DIFF
--- a/models/agent_models.py
+++ b/models/agent_models.py
@@ -26,7 +26,7 @@ class SceneDetail(TypedDict, total=False):
 class AgentBaseModel(BaseModel):
     """Base model supporting mapping style access."""
 
-    model_config: ConfigDict = ConfigDict(from_attributes=True, extra="allow")
+    model_config = ConfigDict(from_attributes=True, extra="allow")
 
     def __getitem__(self, item: str) -> Any:  # pragma: no cover - convenience
         return getattr(self, item)
@@ -53,6 +53,9 @@ class ProblemDetail(AgentBaseModel):
     sentence_char_start: int | None = None
     sentence_char_end: int | None = None
     suggested_fix_focus: str
+    rewrite_instruction: str | None = None
+    severity: str | None = None
+    related_spans: list[tuple[int, int]] | None = None
 
 
 class EvaluationResult(AgentBaseModel):

--- a/processing/evaluation_helpers.py
+++ b/processing/evaluation_helpers.py
@@ -1,3 +1,4 @@
+# processing/evaluation_helpers.py
 from typing import Any
 
 import structlog
@@ -79,6 +80,9 @@ async def parse_llm_evaluation_output(
             suggested_fix_focus=problem_dict.get(
                 "suggested_fix_focus", "N/A - Missing suggestion from LLM"
             ),
+            rewrite_instruction=problem_dict.get("rewrite_instruction"),
+            severity=problem_dict.get("severity"),
+            related_spans=problem_dict.get("related_spans"),
         )
 
         if (

--- a/processing/evaluation_pipeline.py
+++ b/processing/evaluation_pipeline.py
@@ -1,0 +1,60 @@
+# processing/evaluation_pipeline.py
+"""Unified evaluation pipeline coordinating multiple checks."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import structlog
+from agents.comprehensive_evaluator_agent import ComprehensiveEvaluatorAgent
+from agents.world_continuity_agent import WorldContinuityAgent
+
+from models import ProblemDetail
+
+from .repetition_analyzer import RepetitionAnalyzer
+
+logger = structlog.get_logger(__name__)
+
+
+class EvaluationPipeline:
+    """Run evaluator agents and algorithmic checks."""
+
+    def __init__(self) -> None:
+        self.comp_agent = ComprehensiveEvaluatorAgent()
+        self.continuity_agent = WorldContinuityAgent()
+        self.repetition_analyzer = RepetitionAnalyzer()
+
+    async def run(
+        self,
+        plot_outline: dict[str, Any],
+        draft_text: str,
+        chapter_number: int,
+        previous_chapters_context: str,
+    ) -> list[ProblemDetail]:
+        """Return consolidated problem list for ``draft_text``."""
+        logger.info("EvaluationPipeline running", chapter=chapter_number)
+        problems: list[ProblemDetail] = []
+        eval_result, _ = await self.comp_agent.evaluate_chapter_draft(
+            plot_outline,
+            [],
+            {},
+            draft_text,
+            chapter_number,
+            None,
+            0,
+            previous_chapters_context,
+        )
+        problems.extend(eval_result.problems_found)
+
+        continuity_probs, _ = await self.continuity_agent.check_consistency(
+            plot_outline,
+            draft_text,
+            chapter_number,
+            previous_chapters_context,
+        )
+        problems.extend(continuity_probs)
+
+        repetition_probs = await self.repetition_analyzer.analyze(draft_text)
+        problems.extend(repetition_probs)
+
+        return sorted(problems, key=lambda p: p.get("issue_category", ""))

--- a/processing/problem_parser.py
+++ b/processing/problem_parser.py
@@ -67,6 +67,9 @@ def parse_problem_list(text: str, category: str | None = None) -> list[ProblemDe
             suggested_fix_focus=item.get(
                 "suggested_fix_focus", "N/A - Missing suggestion"
             ),
+            rewrite_instruction=item.get("rewrite_instruction"),
+            severity=item.get("severity"),
+            related_spans=item.get("related_spans"),
         )
         if category:
             prob.issue_category = category

--- a/processing/repetition_analyzer.py
+++ b/processing/repetition_analyzer.py
@@ -1,0 +1,48 @@
+# processing/repetition_analyzer.py
+"""Analyze drafts for repeated text patterns."""
+
+from __future__ import annotations
+
+from collections import Counter
+
+import structlog
+import utils
+
+from models import ProblemDetail
+
+logger = structlog.get_logger(__name__)
+
+
+class RepetitionAnalyzer:
+    """Detect repeated n-gram phrases within text."""
+
+    def __init__(self, n: int = 4, threshold: int = 3) -> None:
+        self.n = n
+        self.threshold = threshold
+
+    async def analyze(self, text: str) -> list[ProblemDetail]:
+        """Return repetition problems found in ``text``."""
+        deduped_text, _ = await utils.deduplicate_text_segments(text, "sentence")
+        tokens = deduped_text.split()
+        ngrams = [
+            " ".join(tokens[i : i + self.n]) for i in range(len(tokens) - self.n + 1)
+        ]
+        counts = Counter(ngrams)
+        problems: list[ProblemDetail] = []
+        for ngram, count in counts.items():
+            if count >= self.threshold:
+                description = f'Phrase repeated {count} times: "{ngram}"'
+                problems.append(
+                    ProblemDetail(
+                        issue_category="repetition_and_redundancy",
+                        problem_description=description,
+                        quote_from_original_text=ngram,
+                        suggested_fix_focus="Rephrase or remove the repeated phrase.",
+                        severity="medium",
+                        related_spans=None,
+                        rewrite_instruction=None,
+                    )
+                )
+        if problems:
+            logger.info("RepetitionAnalyzer found %s problems", len(problems))
+        return problems

--- a/prompts/comprehensive_evaluator_agent/evaluate_chapter.j2
+++ b/prompts/comprehensive_evaluator_agent/evaluate_chapter.j2
@@ -38,12 +38,13 @@ Your task is to identify specific issues related to these EXACT categories:
 --- END COMPLETE CHAPTER TEXT ---
 
 **Output Format (CRITICAL - JSON ONLY):**
-Provide your evaluation as a JSON array of problem objects. Each object must have these keys: "issue_category", "problem_description", "quote_from_original_text", "suggested_fix_focus".
+Provide your evaluation as a JSON array of problem objects. Each object must have these keys: "issue_category", "problem_description", "quote_from_original_text", "suggested_fix_focus", "rewrite_instruction".
 For `issue_category`, use one of the EXACT category names: CONSISTENCY, PLOT_ARC, THEMATIC_ALIGNMENT, NARRATIVE_DEPTH_AND_LENGTH.
 The `quote_from_original_text` must be a VERBATIM quote (10-50 words) from the chapter text. If general or no quote applies, use "N/A - General Issue".
 If NO problems are found, output an empty JSON array `[]` or a JSON object like {"status": "No significant problems found"}.
 If information is incomplete for any category, explain the limitation within your problem descriptions.
 The `suggested_fix_focus` should provide a direct instruction to revise the text so the problem is fully resolved. For example, if you detect "Sága's corporeality is inconsistent," the `suggested_fix_focus` might be "Rewrite this passage to describe Sága's actions without using physical verbs. Depict its interaction through its control of the environment or remote avatars, consistent with its 'incorporeal' nature."
+Additionally include a concise `rewrite_instruction` summarizing the exact change to make in one or two sentences.
 
 **Ignore the narrative details in the below example. It shows the required format only.**
 **Follow this example structure for your JSON output precisely:**

--- a/tests/test_evaluation_parsing.py
+++ b/tests/test_evaluation_parsing.py
@@ -5,9 +5,10 @@ from processing.evaluation_helpers import parse_llm_evaluation_output
 
 @pytest.mark.asyncio
 async def test_eval_agent_parsing_valid(monkeypatch):
-    data = '[{"issue_category": "plot_arc", "problem_description": "d", "quote_from_original_text": "q", "suggested_fix_focus": "f"}]'
+    data = '[{"issue_category": "plot_arc", "problem_description": "d", "quote_from_original_text": "q", "suggested_fix_focus": "f", "rewrite_instruction": "do it"}]'
     problems = await parse_llm_evaluation_output(data, 1, "text")
     assert problems[0]["issue_category"] == "plot_arc"
+    assert problems[0]["rewrite_instruction"] == "do it"
 
 
 @pytest.mark.asyncio

--- a/tests/test_orchestrator_private_methods.py
+++ b/tests/test_orchestrator_private_methods.py
@@ -3,10 +3,10 @@ from unittest.mock import AsyncMock
 import pytest
 import utils
 from chapter_generation.drafting_service import DraftResult
+from chapter_generation.finalization_service import FinalizationServiceResult
 from chapter_generation.prerequisites_service import PrerequisiteData
 from data_access import character_queries, world_queries
 from initialization.models import PlotOutline
-from chapter_generation.finalization_service import FinalizationServiceResult
 from orchestration.nana_orchestrator import NANA_Orchestrator, RevisionOutcome
 
 from models.user_input_models import (

--- a/tests/test_repetition_analyzer.py
+++ b/tests/test_repetition_analyzer.py
@@ -1,0 +1,11 @@
+import pytest
+from processing.repetition_analyzer import RepetitionAnalyzer
+
+
+@pytest.mark.asyncio
+async def test_repetition_analyzer_basic():
+    text = "hello world " * 4
+    analyzer = RepetitionAnalyzer(n=2, threshold=3)
+    problems = await analyzer.analyze(text)
+    assert problems
+    assert problems[0]["issue_category"] == "repetition_and_redundancy"

--- a/utils/logging.py
+++ b/utils/logging.py
@@ -1,6 +1,7 @@
 # utils/logging.py
 
 """Logging helpers for the Saga system."""
+
 from __future__ import annotations
 
 import logging


### PR DESCRIPTION
## Summary
- introduce `EvaluationPipeline` to coordinate evaluation agents
- implement `RepetitionAnalyzer` for n-gram repetition detection
- extend `ProblemDetail` with rewrite guidance fields
- request `rewrite_instruction` in evaluator prompt
- ensure base model config uses class variable

## Testing Done
- `ruff check .`
- `mypy .` *(fails: numerous type errors)*
- `pytest -v --cov=.`


------
https://chatgpt.com/codex/tasks/task_e_685f8142479c832f92013dd976f4aa83