### PR TITLE
[AGENT] extend patch validation

### DIFF
--- a/tests/test_patch_validation_agent.py
+++ b/tests/test_patch_validation_agent.py
@@ -24,3 +24,41 @@ async def test_validation_accepts_at_threshold(monkeypatch):
     agent = PatchValidationAgent()
     ok, _ = await agent.validate_patch("ctx", {"replace_with": "x"}, [])
     assert ok
+
+
+@pytest.mark.asyncio
+async def test_rewrite_instruction_missing_keyword(monkeypatch):
+    async def fake_call(*_a, **_k):
+        return f"{settings.PATCH_VALIDATION_THRESHOLD + 10} good", None
+
+    monkeypatch.setattr(llm_service, "async_call_llm", fake_call)
+    agent = PatchValidationAgent()
+    problems = [
+        {
+            "problem_description": "lacking dragon",
+            "rewrite_instruction": "mention the dragon",
+        }
+    ]
+    ok, _ = await agent.validate_patch(
+        "ctx", {"replace_with": "A hero wins."}, problems
+    )
+    assert not ok
+
+
+@pytest.mark.asyncio
+async def test_rewrite_instruction_keywords_present(monkeypatch):
+    async def fake_call(*_a, **_k):
+        return f"{settings.PATCH_VALIDATION_THRESHOLD + 10} good", None
+
+    monkeypatch.setattr(llm_service, "async_call_llm", fake_call)
+    agent = PatchValidationAgent()
+    problems = [
+        {
+            "problem_description": "lacking dragon",
+            "rewrite_instruction": "mention the dragon",
+        }
+    ]
+    ok, _ = await agent.validate_patch(
+        "ctx", {"replace_with": "The dragon appears."}, problems
+    )
+    assert ok


### PR DESCRIPTION
## Summary
- ensure rewrite instructions are respected in `PatchValidationAgent`
- add stopword filtering for instruction keyword checks
- test missing and present rewrite instructions

## Agent Changes
- `PatchValidationAgent.validate_patch` now verifies replacement text includes keywords from the rewrite instruction

## Database Changes
- none

## Configuration Changes
- none

## Testing Done
- `ruff check .`
- `mypy .` *(fails: 105 errors)*
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_68600e2afe7c832fb9c8e0b86c885b5b