### PR TITLE
[PROCESSING] enhance repetition detection

### DIFF
--- a/chapter_generation/finalization_service.py
+++ b/chapter_generation/finalization_service.py
@@ -87,6 +87,8 @@ class FinalizationService:
             chapter_number, final_text_to_process, final_raw_llm_output
         )
 
+        self.orchestrator.repetition_tracker.update_from_text(final_text_to_process)
+
         self.orchestrator.chapter_count = max(
             self.orchestrator.chapter_count, chapter_number
         )

--- a/chapter_generation/revision_service.py
+++ b/chapter_generation/revision_service.py
@@ -73,6 +73,7 @@ class RevisionService:
                 continuity_problems,
                 eval_usage,
                 continuity_usage,
+                repetition_problems,
             ) = await self.orchestrator._run_evaluation_cycle(
                 chapter_number,
                 attempt,
@@ -106,6 +107,11 @@ class RevisionService:
                 f"continuity_problems_attempt_{attempt}",
                 continuity_problems,
             )
+            await self.orchestrator._save_debug_output(
+                chapter_number,
+                f"repetition_problems_attempt_{attempt}",
+                repetition_problems,
+            )
 
             if continuity_problems:
                 logger.warning(
@@ -122,6 +128,13 @@ class RevisionService:
                     "Continuity issues identified by WorldContinuityAgent."
                 )
                 evaluation_result.reasons = sorted(list(unique_reasons))
+
+            if repetition_problems:
+                evaluation_result.problems_found.extend(repetition_problems)
+                if not evaluation_result.needs_revision:
+                    evaluation_result.needs_revision = True
+                if "Repetition issues detected" not in evaluation_result.reasons:
+                    evaluation_result.reasons.append("Repetition issues detected")
 
             needs_revision = evaluation_result.needs_revision
             if not needs_revision:

--- a/config.py
+++ b/config.py
@@ -235,6 +235,11 @@ class SagaSettings(BaseSettings):
     DEDUPLICATION_SEMANTIC_THRESHOLD: float = 0.85
     DEDUPLICATION_MIN_SEGMENT_LENGTH: int = 150
 
+    # Repetition Tracking
+    REPETITION_TRACKER_NGRAM_SIZE: int = 4
+    REPETITION_TRACKER_THRESHOLD: int = 5
+    REPETITION_STATS_FILE: str = "repetition_stats.json"
+
     # Logging & UI
     LOG_LEVEL_STR: str = Field("INFO", alias="AGENT_LOG_LEVEL")
     LOG_FORMAT: str = (
@@ -394,6 +399,9 @@ WORLD_BUILDER_FILE = os.path.join(settings.BASE_OUTPUT_DIR, settings.WORLD_BUILD
 CHAPTERS_DIR = os.path.join(settings.BASE_OUTPUT_DIR, settings.CHAPTERS_DIR)
 CHAPTER_LOGS_DIR = os.path.join(settings.BASE_OUTPUT_DIR, settings.CHAPTER_LOGS_DIR)
 DEBUG_OUTPUTS_DIR = os.path.join(settings.BASE_OUTPUT_DIR, settings.DEBUG_OUTPUTS_DIR)
+REPETITION_STATS_FILE_PATH = os.path.join(
+    settings.BASE_OUTPUT_DIR, settings.REPETITION_STATS_FILE
+)
 UNHINGED_GENRES_FILE = os.path.join(
     settings.UNHINGED_DATA_DIR, settings.UNHINGED_GENRES_FILE
 )

--- a/orchestration/nana_orchestrator.py
+++ b/orchestration/nana_orchestrator.py
@@ -44,6 +44,7 @@ from kg_maintainer.models import (
     SceneDetail,
     WorldItem,
 )
+from processing.repetition_tracker import RepetitionTracker
 from processing.revision_manager import RevisionManager
 from processing.text_deduplicator import TextDeduplicator
 from storage.file_manager import FileManager
@@ -87,6 +88,7 @@ class NANA_Orchestrator:
         self.pre_flight_agent = PreFlightCheckAgent()
         self.finalize_agent = FinalizeAgent(self.kg_maintainer_agent)
         self.revision_manager = RevisionManager()
+        self.repetition_tracker = RepetitionTracker()
 
         # Chapter generation services
         self.prerequisites_service = PrerequisitesService(self, self.file_manager)
@@ -385,6 +387,7 @@ class NANA_Orchestrator:
         list[ProblemDetail],
         dict[str, int] | None,
         dict[str, int] | None,
+        list[ProblemDetail],
     ]:
         result = await self.evaluation_service.run_cycle(
             chapter_number=novel_chapter_number,
@@ -400,6 +403,7 @@ class NANA_Orchestrator:
             result.continuity_problems,
             result.eval_usage,
             result.continuity_usage,
+            result.repetition_problems,
         )
 
     async def _handle_no_evaluation_fast_path(

--- a/processing/repetition_analyzer.py
+++ b/processing/repetition_analyzer.py
@@ -7,8 +7,10 @@ from collections import Counter
 
 import structlog
 import utils
+from config import settings
 
 from models import ProblemDetail
+from processing.repetition_tracker import RepetitionTracker
 
 logger = structlog.get_logger(__name__)
 
@@ -16,9 +18,21 @@ logger = structlog.get_logger(__name__)
 class RepetitionAnalyzer:
     """Detect repeated n-gram phrases within text."""
 
-    def __init__(self, n: int = 4, threshold: int = 3) -> None:
+    def __init__(
+        self,
+        n: int = 4,
+        threshold: int = 3,
+        tracker: RepetitionTracker | None = None,
+        cross_threshold: int | None = None,
+    ) -> None:
         self.n = n
         self.threshold = threshold
+        self.tracker = tracker
+        self.cross_threshold = (
+            cross_threshold
+            if cross_threshold is not None
+            else settings.REPETITION_TRACKER_THRESHOLD
+        )
 
     async def analyze(self, text: str) -> list[ProblemDetail]:
         """Return repetition problems found in ``text``."""
@@ -39,6 +53,27 @@ class RepetitionAnalyzer:
                         quote_from_original_text=ngram,
                         suggested_fix_focus="Rephrase or remove the repeated phrase.",
                         severity="medium",
+                        related_spans=None,
+                        rewrite_instruction=None,
+                    )
+                )
+            if (
+                self.tracker
+                and self.tracker.phrase_counts.get(ngram, 0) >= self.cross_threshold
+            ):
+                description = (
+                    f'Phrase "{ngram}" overused across novel '
+                    f"({self.tracker.phrase_counts.get(ngram, 0)} times)"
+                )
+                problems.append(
+                    ProblemDetail(
+                        issue_category="repetition_and_redundancy",
+                        problem_description=description,
+                        quote_from_original_text=ngram,
+                        suggested_fix_focus=(
+                            "Replace or rephrase to avoid novel-wide repetition."
+                        ),
+                        severity="low",
                         related_spans=None,
                         rewrite_instruction=None,
                     )

--- a/processing/repetition_tracker.py
+++ b/processing/repetition_tracker.py
@@ -1,0 +1,64 @@
+# processing/repetition_tracker.py
+"""Track phrase usage across the novel for repetition detection."""
+
+from __future__ import annotations
+
+import json
+import os
+from collections import Counter
+from collections import Counter as CounterType
+
+import structlog
+from config import REPETITION_STATS_FILE_PATH, settings
+
+logger = structlog.get_logger(__name__)
+
+
+class RepetitionTracker:
+    """Maintain counts of n-gram phrases across chapters."""
+
+    def __init__(
+        self,
+        file_path: str = REPETITION_STATS_FILE_PATH,
+        n: int = settings.REPETITION_TRACKER_NGRAM_SIZE,
+    ) -> None:
+        self.file_path = file_path
+        self.n = n
+        self.phrase_counts: CounterType[str] = Counter()
+        self._load()
+
+    def _load(self) -> None:
+        if os.path.exists(self.file_path):
+            try:
+                with open(self.file_path, encoding="utf-8") as f:
+                    data = json.load(f)
+                for phrase, count in data.items():
+                    self.phrase_counts[phrase] = int(count)
+            except Exception as exc:  # pragma: no cover - log and continue
+                logger.error("Failed loading repetition stats", exc_info=exc)
+
+    def _save(self) -> None:
+        try:
+            with open(self.file_path, "w", encoding="utf-8") as f:
+                json.dump(self.phrase_counts, f)
+        except Exception as exc:  # pragma: no cover - log and continue
+            logger.error("Failed saving repetition stats", exc_info=exc)
+
+    def update_from_text(self, text: str) -> None:
+        tokens = text.split()
+        for i in range(len(tokens) - self.n + 1):
+            phrase = " ".join(tokens[i : i + self.n])
+            self.phrase_counts[phrase] += 1
+        self._save()
+
+    def find_overused(self, text: str, threshold: int | None = None) -> set[str]:
+        limit = (
+            threshold
+            if threshold is not None
+            else settings.REPETITION_TRACKER_THRESHOLD
+        )
+        tokens = text.split()
+        phrases = {
+            " ".join(tokens[i : i + self.n]) for i in range(len(tokens) - self.n + 1)
+        }
+        return {p for p in phrases if self.phrase_counts.get(p, 0) >= limit}

--- a/tests/test_repetition_tracker.py
+++ b/tests/test_repetition_tracker.py
@@ -1,0 +1,13 @@
+import pytest
+from processing.repetition_analyzer import RepetitionAnalyzer
+from processing.repetition_tracker import RepetitionTracker
+
+
+@pytest.mark.asyncio
+async def test_repetition_tracker_overuse(tmp_path):
+    stats_file = tmp_path / "stats.json"
+    tracker = RepetitionTracker(file_path=str(stats_file), n=2)
+    tracker.update_from_text("alpha beta gamma alpha beta")
+    analyzer = RepetitionAnalyzer(n=2, threshold=3, tracker=tracker, cross_threshold=1)
+    problems = await analyzer.analyze("alpha beta")
+    assert any("overused" in p.problem_description for p in problems)

--- a/tests/test_revision_loop.py
+++ b/tests/test_revision_loop.py
@@ -39,6 +39,7 @@ async def test_revision_loop_retries_on_failure(monkeypatch):
             [],
             {},
             {},
+            [],
         )
 
     call_counter = {"count": 0}


### PR DESCRIPTION
## Summary
- add novel-wide repetition tracker
- integrate tracker with evaluation cycle
- update finalization to record phrase stats
- update revision logic to incorporate repetition fixes
- test repetition tracker behavior

## Testing
- `ruff check . && ruff format --check .`
- `mypy .` *(fails: Found 107 errors)*
- `pytest -v tests/test_evaluation_cycle.py::test_ignore_spans_all_attempts`
- `pytest -v --cov=. --cov-report=html`

------
https://chatgpt.com/codex/tasks/task_e_686073b29ab8832f9789e295bb79d01e