### PR TITLE
[AGENT] add KG reasoning provider

### DIFF
--- a/chapter_generation/context_providers.py
+++ b/chapter_generation/context_providers.py
@@ -87,6 +87,21 @@ class KGFactProvider(ContextProvider):
         return ContextChunk(text=text, tokens=tokens, provenance={}, source=self.source)
 
 
+class KGReasoningProvider(ContextProvider):
+    """Provide reasoning constraints derived from the KG."""
+
+    source = "kg_reasoning"
+
+    async def get_context(self, request: ContextRequest) -> ContextChunk:
+        from prompt_data_getters import get_kg_reasoning_guidance_for_prompt
+
+        text = await get_kg_reasoning_guidance_for_prompt(
+            request.plot_outline, request.chapter_number, request.chapter_plan
+        )
+        tokens = count_tokens(text, "dummy")
+        return ContextChunk(text=text, tokens=tokens, provenance={}, source=self.source)
+
+
 class PlanProvider(ContextProvider):
     """Provide the chapter scene plan."""
 

--- a/config.py
+++ b/config.py
@@ -189,6 +189,7 @@ class SagaSettings(BaseSettings):
     CONTEXT_PROVIDERS: list[str] = [
         "chapter_generation.context_providers.SemanticHistoryProvider",
         "chapter_generation.context_providers.KGFactProvider",
+        "chapter_generation.context_providers.KGReasoningProvider",
         "chapter_generation.context_providers.PlanProvider",
         "chapter_generation.context_providers.UserNoteProvider",
     ]

--- a/tests/test_context_providers.py
+++ b/tests/test_context_providers.py
@@ -2,6 +2,7 @@ import pytest
 from chapter_generation.context_providers import (
     ContextRequest,
     KGFactProvider,
+    KGReasoningProvider,
     PlanProvider,
     UserNoteProvider,
 )
@@ -35,3 +36,17 @@ async def test_kg_fact_provider(monkeypatch):
     request = ContextRequest(2, None, {})
     chunk = await provider.get_context(request)
     assert chunk.text == "fact"
+
+
+@pytest.mark.asyncio
+async def test_kg_reasoning_provider(monkeypatch):
+    async def fake_reason(*args, **kwargs):
+        return "guide"
+
+    monkeypatch.setattr(
+        "prompt_data_getters.get_kg_reasoning_guidance_for_prompt", fake_reason
+    )
+    provider = KGReasoningProvider()
+    request = ContextRequest(2, None, {})
+    chunk = await provider.get_context(request)
+    assert chunk.text == "guide"


### PR DESCRIPTION
## Summary
- add KG reasoning guidance fetching in `prompt_data_getters`
- expose new `KGReasoningProvider` for context generation
- include provider in default config
- test `KGReasoningProvider` integration

## Testing Done
- `ruff check .`
- `ruff format .`
- `mypy .` *(fails: Found 109 errors)*
- `pytest -v --cov=.`


------
https://chatgpt.com/codex/tasks/task_e_68607c25bc10832fa39b1a3e832f12bf