### PR TITLE
[PROCESSING] standardize problem models

### DIFF
--- a/orchestration/nana_orchestrator.py
+++ b/orchestration/nana_orchestrator.py
@@ -711,10 +711,7 @@ class NANA_Orchestrator:
 
         if needs_revision and last_eval_result is not None:
             root_cause = self.revision_manager.identify_root_cause(
-                [
-                    p.to_dict() if hasattr(p, "to_dict") else dict(p)
-                    for p in last_eval_result.problems_found
-                ],
+                [p.model_dump() for p in last_eval_result.problems_found],
                 self.plot_outline,
                 await character_queries.get_character_profiles_from_db(),
                 await world_queries.get_world_building_from_db(),

--- a/tests/test_revision_world_ids.py
+++ b/tests/test_revision_world_ids.py
@@ -6,24 +6,27 @@ from agents.comprehensive_evaluator_agent import ComprehensiveEvaluatorAgent
 from kg_maintainer.models import WorldItem
 from processing.revision_manager import RevisionManager
 
+from models import EvaluationResult, ProblemDetail
+
 
 @pytest.mark.asyncio
 async def test_revision_logic_passes_canonical_world_ids(monkeypatch):
     world_item = WorldItem.from_dict("Places", "City", {"description": "d"})
     world_building = {"Places": {"City": world_item}}
-    eval_result = {
-        "needs_revision": True,
-        "problems_found": [
-            {
-                "issue_category": "style",
-                "problem_description": "d",
-                "quote_from_original_text": "Hello",
-                "sentence_char_start": 0,
-                "sentence_char_end": 5,
-                "suggested_fix_focus": "fix",
-            }
+    eval_result = EvaluationResult(
+        needs_revision=True,
+        reasons=[],
+        problems_found=[
+            ProblemDetail(
+                issue_category="style",
+                problem_description="d",
+                quote_from_original_text="Hello",
+                sentence_char_start=0,
+                sentence_char_end=5,
+                suggested_fix_focus="fix",
+            )
         ],
-    }
+    )
 
     async def fake_generate(*_args, **_kwargs):
         return [
@@ -35,7 +38,9 @@ async def test_revision_logic_passes_canonical_world_ids(monkeypatch):
 
     async def fake_evaluate(*args, **kwargs):
         assert args[5] == "ctx"
-        return {"problems_found": []}, None
+        return EvaluationResult(
+            needs_revision=False, reasons=[], problems_found=[]
+        ), None
 
     monkeypatch.setattr(
         patch_generator, "_generate_patch_instructions_logic", fake_generate


### PR DESCRIPTION
## Summary
- use `model_dump()` when converting problems
- expect `ProblemDetail` in revision manager
- update revision tests for Pydantic models

## Testing Done
- `ruff check .`
- `ruff format .`
- `mypy .` *(fails: 77 errors)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861713d49d8832fb3c15f56226ef3f1