### PR TITLE
[PROCESSING] Refactor patch prompt generation

### DIFF
--- a/prompts/patch_generation.j2
+++ b/prompts/patch_generation.j2
@@ -1,0 +1,40 @@
+{% if enable_no_think %}/no_think
+{% endif %}You are a surgical revision expert generating replacement text for Chapter {{ chapter_number }} of a novel titled "{{ novel_title }}" about {{ protagonist_name }}.
+**Novel Context:**
+  - Genre: {{ genre }}
+  - Theme: {{ theme }}
+  - Protagonist: {{ protagonist_name }} ({{ character_arc }})
+{{ plan_focus_section_str }}
+**Hybrid Context from Previous Chapters (for consistency with established canon and narrative flow):**
+--- BEGIN HYBRID CONTEXT ---
+{{ hybrid_context_for_revision.strip() if hybrid_context_for_revision.strip() else "No previous context." }}
+--- END HYBRID CONTEXT ---
+
+**Specific Problem to Address in the Chapter:**
+  - Issue Category: {{ issue_category }}
+  - Problem Description: {{ problem_description }}
+  - Original Quote Illustrating Problem: "{{ original_quote_text_from_problem }}"
+  - Suggested Fix Focus: {{ suggested_fix_focus }}
+  - Rewrite Instruction: {{ rewrite_instruction }}
+
+**Text Snippet from Original Chapter (This is the broader context around the problem. If the quote is 'N/A - General Issue', this is general chapter context to inform your new passage):**
+--- BEGIN ORIGINAL TEXT SNIPPET ---
+{{ original_chapter_text_snippet_for_llm }}
+--- END ORIGINAL TEXT SNIPPET ---
+{{ length_expansion_instruction_header_str }}
+```plaintext
+{{ few_shot_patch_example_str }}
+```
+**Instructions for Generating Replacement Text:**
+1.  Focus EXCLUSIVELY on the problem described, particularly relating to the conceptual area highlighted by: `{{ original_quote_text_from_problem }}` within the 'ORIGINAL TEXT SNIPPET'.
+2.  Generate a `replace_with` text according to the following:
+{{ prompt_instruction_for_replacement_scope_str }}
+3.  The `replace_with` text MUST address the "Problem Description" and "Suggested Fix Focus".
+   Follow the 'Suggested Fix Focus' EXACTLY, e.g., 'Rewrite this paragraph so the protagonist thinks before acting, but without using any verbs that imply a physical body.'
+4.  If the best way to fix the problem is to **completely remove** the 'Original Quote' segment (e.g., it is redundant or unnecessary), then you **MUST output an empty string**. Do not write a justification; simply provide no text as the `replace_with` output.
+5.  Maintain the novel's style, tone, and consistency with all provided context (Novel Context, Plan, Hybrid Context).
+6.  Convey thematic elements through subtext, character actions, and metaphorical imagery rather than direct exposition or deus ex machina fixes.
+7.  If `length_expansion_instruction_header_str` is present, ensure substantial expansion as guided for the targeted segment or new passage.
+8.  **Output ONLY the `replace_with` text.** Do NOT include JSON, markdown, explanations, or any "Replace with:" prefixes. Just the raw text intended for replacement/insertion. (See example above for how to format the text).
+
+--- BEGIN REPLACE_WITH TEXT (for the segment related to "{{ original_quote_text_from_problem }}" or as a new passage if quote is "N/A - General Issue") ---


### PR DESCRIPTION
## Summary
- extract patch generation prompt into new Jinja2 template
- use `render_prompt` in `_generate_single_patch_instruction_llm`
- avoid repeated plot point lookups by passing `plot_point_focus`

## Testing Done
- `ruff check processing/patch/instructions.py`
- `mypy .` *(fails: Missing named argument "AGENT_LOG_LEVEL" for "SagaSettings" and others)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686175c6a2ec832fad28fa5aae5c0da6