### PR TITLE
[CORE] Fix provisional flagging for new entities

### DIFF
--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -50,7 +50,9 @@ def test_merge_character_profile_updates_new_from_flawed():
     merge_character_profile_updates(profiles, updates, 1, True)
     prof = profiles["Zoe"]
     assert prof.traits == ["kind"]
-    assert "source_quality_chapter_1" not in prof.updates
+    assert (
+        prof.updates["source_quality_chapter_1"] == "provisional_from_unrevised_draft"
+    )
 
 
 def test_merge_world_item_updates_new_item_flawed():
@@ -59,7 +61,10 @@ def test_merge_world_item_updates_new_item_flawed():
     merge_world_item_updates(current, updates, 3, True)
     item = current["Things"]["Book"]
     assert item.properties["added_in_chapter_3"]
-    assert "source_quality_chapter_3" not in item.properties
+    assert (
+        item.properties["source_quality_chapter_3"]
+        == "provisional_from_unrevised_draft"
+    )
 
 
 def test_merge_world_item_updates_merge_complex():


### PR DESCRIPTION
## Summary
- ensure new character profiles get provisional flag when parsed from a flawed draft
- propagate provisional flagging to new world items
- update merge tests for the new behavior

## Agent Changes
- none

## Database Changes
- none

## Configuration Changes
- none

## Testing Done
- `ruff check .`
- `ruff format .`
- `mypy .` *(fails: 77 errors)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686178124050832f8c5aa47e6ab2df39