### PR TITLE
[AGENT] track chapter end state

### DIFF
--- a/agents/finalize_agent.py
+++ b/agents/finalize_agent.py
@@ -78,9 +78,12 @@ class FinalizeAgent:
             final_text,
             from_flawed_draft,
         )
+        end_state_task = self.kg_agent.generate_chapter_end_state(
+            final_text, chapter_number
+        )
 
-        (summary_data, embedding, kg_usage) = await asyncio.gather(
-            summary_task, embedding_task, kg_task
+        (summary_data, embedding, kg_usage, end_state) = await asyncio.gather(
+            summary_task, embedding_task, kg_task, end_state_task
         )
         summary, summary_usage = summary_data
 
@@ -91,6 +94,7 @@ class FinalizeAgent:
             summary,
             embedding,
             from_flawed_draft,
+            end_state.model_dump(),
         )
 
         return {

--- a/agents/patch_validation_agent.py
+++ b/agents/patch_validation_agent.py
@@ -73,7 +73,7 @@ class PatchValidationAgent:
         """
 
         issues_list = "\n".join(
-            f"- {getattr(p, 'problem_description', p.problem_description, '')}"
+            f"- {p.get('problem_description', '') if isinstance(p, dict) else p.problem_description}"
             for p in problems
         )
         prompt = render_prompt(
@@ -128,7 +128,11 @@ class PatchValidationAgent:
         patch_text_lower = patch.get("replace_with", "").lower()
         keywords: list[str] = []
         for p in problems:
-            instr = getattr(p, "rewrite_instruction", p.rewrite_instruction, "")
+            instr = (
+                p.get("rewrite_instruction", "")
+                if isinstance(p, dict)
+                else p.rewrite_instruction
+            )
             for word in instr.split():
                 clean = word.strip(string.punctuation).lower()
                 if clean and clean not in STOPWORDS:

--- a/config.py
+++ b/config.py
@@ -188,6 +188,7 @@ class SagaSettings(BaseSettings):
     CONTEXT_CACHE_TTL: float = 600.0
     CONTEXT_PROVIDERS: list[str] = [
         "chapter_generation.context_providers.SemanticHistoryProvider",
+        "chapter_generation.context_providers.StateContextProvider",
         "chapter_generation.context_providers.CanonProvider",
         "chapter_generation.context_providers.KGFactProvider",
         "chapter_generation.context_providers.KGReasoningProvider",

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,6 +1,8 @@
 """Central package for SAGA data models."""
 
 from .agent_models import (
+    ChapterEndState,
+    CharacterState,
     EvaluationResult,
     PatchInstruction,
     ProblemDetail,
@@ -24,6 +26,8 @@ __all__ = [
     "ProblemDetail",
     "EvaluationResult",
     "PatchInstruction",
+    "CharacterState",
+    "ChapterEndState",
     "CharacterProfile",
     "WorldItem",
     "NovelConceptModel",

--- a/models/agent_models.py
+++ b/models/agent_models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, TypedDict
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class SceneDetail(TypedDict, total=False):
@@ -79,3 +79,21 @@ class PatchInstruction(AgentBaseModel):
     target_char_end: int | None = None
     replace_with: str
     reason_for_change: str
+
+
+class CharacterState(AgentBaseModel):
+    """State information for a character at chapter end."""
+
+    name: str
+    status: str
+    location: str
+    immediate_goal: str | None = None
+
+
+class ChapterEndState(AgentBaseModel):
+    """Snapshot of the world at the end of a chapter."""
+
+    chapter_number: int
+    character_states: list[CharacterState]
+    unresolved_cliffhanger: str | None = None
+    key_world_changes: dict[str, str] = Field(default_factory=dict)

--- a/prompts/kg_maintainer_agent/chapter_end_state.j2
+++ b/prompts/kg_maintainer_agent/chapter_end_state.j2
@@ -1,0 +1,18 @@
+{% if enable_no_think %}/no_think{% endif %}
+You analyze the final state of Chapter {{ chapter_number }}. For every significant character, specify exactly where they are and their status at the end of the chapter. Include any immediate goal they are focused on as the chapter closes. Summarize any key world changes that occurred and note one unresolved cliffhanger if present.
+Output a single JSON object matching this schema:
+{
+  "chapter_number": <int>,
+  "character_states": [
+    {"name": "<Name>", "status": "<Status>", "location": "<Location>", "immediate_goal": "<Goal>"},
+    ...
+  ],
+  "unresolved_cliffhanger": "<Question>?",
+  "key_world_changes": {"Location or Faction": "Description"}
+}
+Use concise phrasing based strictly on the provided text.
+Chapter text to analyze:
+"""
+{{ chapter_text }}
+"""
+


### PR DESCRIPTION
## Summary
- add `ChapterEndState` model and export in `models/__init__`
- generate chapter end state with KG maintainer
- persist end state JSON when saving chapters
- add new `StateContextProvider` to inject continuity
- include new provider in settings
- update finalize agent and tests
- fix patch validation handling of dict problem details

## Testing Done
- `ruff check .`
- `mypy .` *(fails: 84 errors)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686340586ebc832f9c4dc1769f51afb0