### PR TITLE
[AGENT] switch patch validation to LLM

### DIFF
--- a/processing/patch/instructions.py
+++ b/processing/patch/instructions.py
@@ -1,3 +1,4 @@
+# processing/patch/instructions.py
 """Patch instruction generation utilities."""
 
 import asyncio
@@ -192,7 +193,12 @@ A chill traced Elara's spine, not from the crypt's cold, but from the translucen
             "length_expansion_instruction_header_str": length_expansion_instruction_header_str,
             "few_shot_patch_example_str": few_shot_patch_example_str.strip(),
             "prompt_instruction_for_replacement_scope_str": prompt_instruction_for_replacement_scope_str,
-            "validation_failure_reason": validation_failure_reason,
+            "validation_failure_reason": (
+                f"The previous attempt to fix this issue failed validation for the following reason: '{validation_failure_reason}'. "
+                "Your new `replace_with` text MUST address this feedback directly."
+                if validation_failure_reason
+                else None
+            ),
         },
     )
 

--- a/prompts/patch_validation_agent/validate_patch.j2
+++ b/prompts/patch_validation_agent/validate_patch.j2
@@ -1,13 +1,10 @@
 /no_think
-You are a meticulous editor checking whether a proposed patch resolves all listed issues without harming continuity.
+You are a meticulous editor. Does the "Proposed Replacement Text" successfully fix the "Identified Problem"?
+Analyze the problem description, the quote, and the proposed replacement.
 
-**Context Snippet:**
-{{ context_snippet }}
+**Identified Problem:** {{ problem.problem_description if problem else "" }}
+**Original Quote from Text:** "{{ problem.quote_from_original_text if problem else "" }}"
+**Proposed Replacement Text:** "{{ patch.replace_with }}"
 
-**Patch Text:**
-{{ patch_text }}
-
-**Issues to Resolve:**
-{{ issues_list }}
-
-Respond with a single line beginning with a number from 0-100 indicating how well the patch resolves the issues (100 = fully resolved). Optionally add a brief reason after the number.
+Respond with a single word on the first line: YES or NO.
+On the second line, provide a one-sentence justification for your answer.

--- a/tests/test_revision_patching.py
+++ b/tests/test_revision_patching.py
@@ -372,7 +372,7 @@ async def test_patch_validation_toggle(monkeypatch):
 @pytest.mark.asyncio
 async def test_patch_validation_scores(monkeypatch):
     async def fake_call(*_args, **_kwargs):
-        return "85 good", None
+        return "YES\nok", None
 
     monkeypatch.setattr(llm_service, "async_call_llm", fake_call)
 
@@ -381,7 +381,7 @@ async def test_patch_validation_scores(monkeypatch):
     assert ok
 
     async def fake_call_low(*_args, **_kwargs):
-        return "60 needs work", None
+        return "NO\nbad", None
 
     monkeypatch.setattr(llm_service, "async_call_llm", fake_call_low)
     agent2 = PatchValidationAgent()


### PR DESCRIPTION
## Summary
- simplify patch validation by asking LLM if the replacement fixes the problem
- pass validation failure reason explicitly into patch-generation prompt
- adjust tests for new yes/no validation flow

## Agent Changes
- `PatchValidationAgent.validate_patch` uses an LLM-based YES/NO check

## Testing Done
- `ruff check .`
- `mypy agents/patch_validation_agent.py processing/patch/instructions.py tests/test_patch_validation_agent.py tests/test_revision_patching.py` *(fails: see log)*
- `pytest -q` *(fails: 2 tests)*

------
https://chatgpt.com/codex/tasks/task_e_68639397d0cc832faeee23dcf6da1f39