### PR TITLE
[AGENT] switch patch validation to llm

### DIFF
--- a/agents/patch_validation_agent.py
+++ b/agents/patch_validation_agent.py
@@ -11,33 +11,6 @@ from prompt_renderer import render_prompt
 
 from models import PatchInstruction, ProblemDetail
 
-STOPWORDS = {
-    "the",
-    "a",
-    "an",
-    "and",
-    "or",
-    "for",
-    "with",
-    "without",
-    "to",
-    "from",
-    "by",
-    "of",
-    "in",
-    "on",
-    "at",
-    "include",
-    "mention",
-    "use",
-    "add",
-    "make",
-    "this",
-    "that",
-    "these",
-    "those",
-}
-
 logger = structlog.get_logger(__name__)
 
 
@@ -55,6 +28,10 @@ class PatchValidationAgent:
         problems: list[ProblemDetail],
     ) -> tuple[bool, str | None, dict[str, int] | None]:
         """Validate a single patch via an LLM call.
+
+        The LLM prompt asks whether the replacement text resolves the identified
+        problem. The response must begin with ``YES`` or ``NO`` on the first
+        line, followed by an optional justification on the second line.
 
         Args:
             context_snippet: Unused snippet of surrounding text.

--- a/processing/patch/instructions.py
+++ b/processing/patch/instructions.py
@@ -193,12 +193,7 @@ A chill traced Elara's spine, not from the crypt's cold, but from the translucen
             "length_expansion_instruction_header_str": length_expansion_instruction_header_str,
             "few_shot_patch_example_str": few_shot_patch_example_str.strip(),
             "prompt_instruction_for_replacement_scope_str": prompt_instruction_for_replacement_scope_str,
-            "validation_failure_reason": (
-                f"The previous attempt to fix this issue failed validation for the following reason: '{validation_failure_reason}'. "
-                "Your new `replace_with` text MUST address this feedback directly."
-                if validation_failure_reason
-                else None
-            ),
+            "validation_failure_reason": validation_failure_reason,
         },
     )
 

--- a/prompts/patch_generation.j2
+++ b/prompts/patch_generation.j2
@@ -25,7 +25,7 @@ You are a surgical revision expert generating replacement text for Chapter {{ ch
 ```plaintext
 {{ few_shot_patch_example_str }}
 ```
-{% if validation_failure_reason %}**Previous Attempt Failed Validation:** {{ validation_failure_reason }}. Please generate a new patch that corrects this.{% endif %}
+{% if validation_failure_reason %}**Previous Attempt Failed Validation:** The previous attempt to fix this issue failed validation for the following reason: '{{ validation_failure_reason }}'. Your new `replace_with` text MUST address this feedback directly.{% endif %}
 **Instructions for Generating Replacement Text:**
 1.  Focus EXCLUSIVELY on the problem described, particularly relating to the conceptual area highlighted by: `{{ original_quote_text_from_problem }}` within the 'ORIGINAL TEXT SNIPPET'.
 2.  Generate a `replace_with` text according to the following:


### PR DESCRIPTION
## Summary
- clean up PatchValidationAgent and document LLM semantics
- propagate previous validation failure reason directly into patch prompt
- make patch generation prompt explicitly mention prior failure

## Agent Changes
- PatchValidationAgent uses LLM YES/NO validation

## Database Changes
- none

## Configuration Changes
- none

## Testing Done
- `ruff check agents/patch_validation_agent.py processing/patch/instructions.py`
- `ruff format agents/patch_validation_agent.py processing/patch/instructions.py`
- `mypy .` *(fails: 80 errors)*
- `pytest -q` *(fails: 3 failed, 182 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6864017f7c7c832f85fbb1a3d3697908