### PR TITLE
[PROCESSING] Fix context cache key handling

### DIFF
--- a/tests/test_context_orchestrator.py
+++ b/tests/test_context_orchestrator.py
@@ -25,3 +25,17 @@ async def test_orchestrator_truncates(monkeypatch):
     out = await orch.build_context(req)
     assert "A" in out
     assert "B" not in out or "defghij" not in out
+
+
+@pytest.mark.asyncio
+async def test_agent_hints_cache_key():
+    orch = ContextOrchestrator([DummyProvider("abc", "A")])
+    req = ContextRequest(
+        1,
+        None,
+        {},
+        agent_hints={"notes": ["a", {"b": 1}]},
+    )
+    out1 = await orch.build_context(req)
+    out2 = await orch.build_context(req)
+    assert out1 == out2


### PR DESCRIPTION
## Summary
- handle complex agent hints when caching context data
- test caching with complex agent hints

## Testing Done
- `ruff format chapter_generation/context_orchestrator.py tests/test_context_orchestrator.py`
- `ruff check chapter_generation/context_orchestrator.py tests/test_context_orchestrator.py`
- `mypy chapter_generation/context_orchestrator.py tests/test_context_orchestrator.py` *(fails: 29 errors in 13 files)*
- `pytest -v --cov=.` *(fails: 3 failed, 183 passed, 8 xfailed)*

------
https://chatgpt.com/codex/tasks/task_e_6864089f0b3c832faa7d9ef74d1e9659