### PR TITLE
[PROCESSING] Scoped plot outline for evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ python main.py
 *   **First Run:** SAGA will perform initial setup (plot, world, characters based on `user_story_elements.yaml` or generation) and pre-populate the Neo4j knowledge graph.
 *   **Subsequent Runs:** It will load the existing state from Neo4j and continue generating chapters from where it left off.
 *   The orchestrator recalculates pending plot points before each chapter and continues until none remain or `CHAPTERS_PER_RUN` chapters have been written.
+*   Evaluation prompts now include only the active plot point and the next one to keep feedback focused.
 
 Output files (chapters, logs, debug information) will be saved in the directory specified by `BASE_OUTPUT_DIR` (default: `novel_output`). This directory is ignored by Git to keep generated data out of version control.
 

--- a/orchestration/nana_orchestrator.py
+++ b/orchestration/nana_orchestrator.py
@@ -399,9 +399,12 @@ class NANA_Orchestrator:
         ignore_spans = patched_spans
 
         if settings.ENABLE_COMPREHENSIVE_EVALUATION:
+            scoped_outline = utils.get_scoped_plot_outline(
+                self.plot_outline, novel_chapter_number
+            )
             tasks_to_run.append(
                 self.evaluator_agent.evaluate_chapter_draft(
-                    self.plot_outline,
+                    scoped_outline,
                     current_text,
                     novel_chapter_number,
                     plot_point_focus,

--- a/tests/test_scoped_outline.py
+++ b/tests/test_scoped_outline.py
@@ -1,0 +1,41 @@
+# tests/test_scoped_outline.py
+from unittest.mock import AsyncMock
+
+import pytest
+import utils
+from agents.comprehensive_evaluator_agent import ComprehensiveEvaluatorAgent
+from core.llm_interface import llm_service
+from data_access import chapter_queries
+
+
+@pytest.mark.asyncio
+async def test_evaluation_prompt_uses_scoped_plot_points(monkeypatch):
+    monkeypatch.setattr(utils, "load_spacy_model_if_needed", lambda: None)
+    monkeypatch.setattr(
+        llm_service, "async_get_embedding", AsyncMock(return_value=[0.0])
+    )
+    monkeypatch.setattr(
+        chapter_queries, "get_embedding_from_db", AsyncMock(return_value=[0.0])
+    )
+    monkeypatch.setattr(
+        "processing.evaluation_helpers.parse_llm_evaluation_output",
+        AsyncMock(return_value=[]),
+    )
+
+    captured = {}
+
+    async def fake_llm(*args, **kwargs):
+        captured["prompt"] = kwargs.get("prompt") or args[1]
+        return "[]", {}
+
+    monkeypatch.setattr(llm_service, "async_call_llm", fake_llm)
+
+    agent = ComprehensiveEvaluatorAgent()
+    outline = {"plot_points": ["pp1", "pp2", "pp3", "pp4"]}
+    scoped = utils.get_scoped_plot_outline(outline, 3)
+    await agent.evaluate_chapter_draft(scoped, "draft", 3, "pp2", 1, "ctx")
+
+    assert "pp2" in captured["prompt"]
+    assert "pp3" in captured["prompt"]
+    assert "pp1" not in captured["prompt"]
+    assert "- PP 4: pp4" not in captured["prompt"]

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -13,7 +13,7 @@ from core.llm_interface import count_tokens, llm_service
 
 from .helpers import _is_fill_in
 from .logging import setup_logging_nana
-from .plot import get_plot_point_info
+from .plot import get_plot_point_info, get_scoped_plot_outline
 from .similarity import find_semantically_closest_segment, numpy_cosine_similarity
 from .text_processing import (
     SpaCyModelManager,
@@ -231,6 +231,7 @@ __all__ = [
     "get_text_segments",
     "format_scene_plan_for_prompt",
     "get_plot_point_info",
+    "get_scoped_plot_outline",
     "deduplicate_text_segments",
     "remove_spans_from_text",
     "setup_logging_nana",

--- a/utils/plot.py
+++ b/utils/plot.py
@@ -42,3 +42,18 @@ def get_plot_point_info(
         chapter_number,
     )
     return None, -1
+
+
+def get_scoped_plot_outline(
+    plot_outline: dict[str, Any], chapter_number: int, scope: int = 2
+) -> dict[str, Any]:
+    """Return a copy of the outline scoped to plot points near the chapter."""
+
+    plot_points = plot_outline.get("plot_points")
+    if not isinstance(plot_points, list) or scope <= 0:
+        return dict(plot_outline)
+
+    plot_point_index = max((chapter_number - 1) // settings.PLOT_POINT_CHAPTER_SPAN, 0)
+    scoped = dict(plot_outline)
+    scoped["plot_points"] = plot_points[plot_point_index : plot_point_index + scope]
+    return scoped


### PR DESCRIPTION
## Summary
- implement `get_scoped_plot_outline` utility
- use scoped outline in evaluation cycle
- test evaluation prompt scoping
- document scoping behavior in README

## Testing Done
- `ruff check agents/comprehensive_evaluator_agent.py utils/plot.py utils/__init__.py orchestration/nana_orchestrator.py tests/test_scoped_outline.py`
- `mypy .` *(fails: multiple type errors)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686485f6783c832f8cef238883f3ccb0