### PR TITLE
[ORCHESTRATION] async context gathering

### DIFF
--- a/data_access/world_queries.py
+++ b/data_access/world_queries.py
@@ -698,7 +698,7 @@ async def get_world_building_from_db(
 
         # Fetch elaborations with chapter limit
         elab_query_parts = [
-            f"MATCH (:WorldElement:Entity {{id: $we_id_param}})-[:ELABORATED_IN_CHAPTER]->(elab:WorldElaborationEvent:Entity)"
+            "MATCH (:WorldElement:Entity {id: $we_id_param})-[:ELABORATED_IN_CHAPTER]->(elab:WorldElaborationEvent:Entity)"
         ]
         elab_params: dict[str, Any] = {"we_id_param": we_id}
         if chapter_limit is not None:


### PR DESCRIPTION
## Summary
- run context providers concurrently in `ContextOrchestrator`
- fix F541 lint error in `world_queries`
- test new async behaviour for the orchestrator

## Testing Done
- `ruff check .`
- `mypy .` *(fails: 78 errors in 27 files)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864b2f76020832f85c76b471784bb25