### PR TITLE
[ORCHESTRATION] add context profiles

### DIFF
--- a/chapter_generation/__init__.py
+++ b/chapter_generation/__init__.py
@@ -1,6 +1,13 @@
 """Utilities for orchestrating chapter generation steps."""
 
-from .context_orchestrator import ContextOrchestrator, ContextRequest
+from .context_models import (
+    ContextChunk,
+    ContextProfileName,
+    ContextRequest,
+    ProfileConfiguration,
+    ProviderSettings,
+)
+from .context_orchestrator import ContextOrchestrator, create_from_settings
 from .drafting_service import DraftResult
 from .evaluation_service import EvaluationCycleResult
 from .finalization_service import FinalizationServiceResult
@@ -11,6 +18,11 @@ __all__ = [
     "PrerequisiteData",
     "ContextOrchestrator",
     "ContextRequest",
+    "ContextChunk",
+    "ContextProfileName",
+    "ProviderSettings",
+    "ProfileConfiguration",
+    "create_from_settings",
     "DraftResult",
     "EvaluationCycleResult",
     "RevisionResult",

--- a/chapter_generation/context_models.py
+++ b/chapter_generation/context_models.py
@@ -1,0 +1,55 @@
+# chapter_generation/context_models.py
+"""Data models used for context generation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from models.agent_models import SceneDetail
+
+
+class ContextProfileName(str, Enum):
+    """Supported context profiles."""
+
+    DEFAULT = "default"
+    ALTERNATE = "alternate"
+
+
+@dataclass
+class ContextRequest:
+    """Parameters describing the desired context."""
+
+    chapter_number: int
+    plot_focus: str | None
+    plot_outline: dict[str, Any]
+    chapter_plan: list[SceneDetail] | None = None
+    agent_hints: dict[str, Any] | None = None
+    profile_name: ContextProfileName = ContextProfileName.DEFAULT
+
+
+@dataclass
+class ProviderSettings:
+    """Configuration for an individual provider instance."""
+
+    provider: Any
+    max_tokens: int | None = None
+
+
+@dataclass
+class ProfileConfiguration:
+    """List of providers and token limit for a profile."""
+
+    providers: list[ProviderSettings]
+    max_tokens: int
+
+
+@dataclass
+class ContextChunk:
+    """A chunk of context returned by a provider."""
+
+    text: str
+    tokens: int
+    provenance: dict[str, Any]
+    source: str

--- a/chapter_generation/context_providers.py
+++ b/chapter_generation/context_providers.py
@@ -4,37 +4,17 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
 from typing import Any
 
 import structlog
 from config import settings
 from core.llm_interface import count_tokens, llm_service
 
-from models.agent_models import ChapterEndState, SceneDetail
+from models.agent_models import ChapterEndState
+
+from .context_models import ContextChunk, ContextRequest
 
 logger = structlog.get_logger(__name__)
-
-
-@dataclass
-class ContextRequest:
-    """Parameters describing the desired context."""
-
-    chapter_number: int
-    plot_focus: str | None
-    plot_outline: dict[str, Any]
-    chapter_plan: list[SceneDetail] | None = None
-    agent_hints: dict[str, Any] | None = None
-
-
-@dataclass
-class ContextChunk:
-    """A chunk of context returned by a provider."""
-
-    text: str
-    tokens: int
-    provenance: dict[str, Any]
-    source: str
 
 
 class ContextProvider:

--- a/config.py
+++ b/config.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import os
+from typing import Any
 
 import structlog
 from dotenv import load_dotenv
@@ -186,15 +187,20 @@ class SagaSettings(BaseSettings):
     ENABLE_RERANKING: bool = False
     CONTEXT_CACHE_SIZE: int = 16
     CONTEXT_CACHE_TTL: float = 600.0
-    CONTEXT_PROVIDERS: list[str] = [
-        "chapter_generation.context_providers.SemanticHistoryProvider",
-        "chapter_generation.context_providers.StateContextProvider",
-        "chapter_generation.context_providers.CanonProvider",
-        "chapter_generation.context_providers.KGFactProvider",
-        "chapter_generation.context_providers.KGReasoningProvider",
-        "chapter_generation.context_providers.PlanProvider",
-        "chapter_generation.context_providers.UserNoteProvider",
-    ]
+    CONTEXT_PROFILES: dict[str, dict[str, Any]] = {
+        "default": {
+            "max_tokens": 40960,
+            "providers": [
+                "chapter_generation.context_providers.SemanticHistoryProvider",
+                "chapter_generation.context_providers.StateContextProvider",
+                "chapter_generation.context_providers.CanonProvider",
+                "chapter_generation.context_providers.KGFactProvider",
+                "chapter_generation.context_providers.KGReasoningProvider",
+                "chapter_generation.context_providers.PlanProvider",
+                "chapter_generation.context_providers.UserNoteProvider",
+            ],
+        }
+    }
     RERANKER_CANDIDATE_COUNT: int = 15
 
     # Agentic Planning & Prompt Context Snippets

--- a/processing/context_generator.py
+++ b/processing/context_generator.py
@@ -1,20 +1,17 @@
 from __future__ import annotations
 
-import importlib
 from typing import Any
 
-from chapter_generation import ContextOrchestrator, ContextRequest
-from config import settings
+from chapter_generation import (
+    ContextRequest,
+)
+from chapter_generation import (
+    create_from_settings as create_context_service,
+)
 
 from models import SceneDetail
 
-provider_instances = []
-for dotted in settings.CONTEXT_PROVIDERS:
-    module_name, class_name = dotted.rsplit(".", 1)
-    module = importlib.import_module(module_name)
-    cls = getattr(module, class_name)
-    provider_instances.append(cls())
-context_service = ContextOrchestrator(provider_instances)
+context_service = create_context_service()
 
 
 async def _generate_semantic_chapter_context_logic(

--- a/tests/test_context_generator.py
+++ b/tests/test_context_generator.py
@@ -2,7 +2,13 @@ from unittest.mock import AsyncMock
 
 import numpy as np
 import pytest
-from chapter_generation.context_orchestrator import ContextOrchestrator, ContextRequest
+from chapter_generation.context_models import (
+    ContextProfileName,
+    ContextRequest,
+    ProfileConfiguration,
+    ProviderSettings,
+)
+from chapter_generation.context_orchestrator import ContextOrchestrator
 from chapter_generation.context_providers import SemanticHistoryProvider
 from core.llm_interface import llm_service
 from data_access import chapter_queries
@@ -41,7 +47,13 @@ async def test_immediate_context_added(monkeypatch):
     )
 
     provider = SemanticHistoryProvider(chapter_queries, llm_service)
-    orchestrator = ContextOrchestrator([provider])
+    profiles = {
+        ContextProfileName.DEFAULT: ProfileConfiguration(
+            providers=[ProviderSettings(provider)],
+            max_tokens=100,
+        )
+    }
+    orchestrator = ContextOrchestrator(profiles)
     req = ContextRequest(chapter_number=4, plot_focus=None, plot_outline={})
     ctx = await orchestrator.build_context(req)
     assert ctx.startswith("[semantic_history]")
@@ -95,7 +107,13 @@ async def test_decay_sorting(monkeypatch):
     )
 
     provider = SemanticHistoryProvider(chapter_queries, llm_service)
-    orchestrator = ContextOrchestrator([provider])
+    profiles = {
+        ContextProfileName.DEFAULT: ProfileConfiguration(
+            providers=[ProviderSettings(provider)],
+            max_tokens=100,
+        )
+    }
+    orchestrator = ContextOrchestrator(profiles)
     req = ContextRequest(chapter_number=11, plot_focus=None, plot_outline={})
     ctx = await orchestrator.build_context(req)
     pos8 = ctx.index("Semantic Context from Chapter 8")

--- a/tests/test_context_service.py
+++ b/tests/test_context_service.py
@@ -2,7 +2,8 @@ from unittest.mock import AsyncMock
 
 import numpy as np
 import pytest
-from chapter_generation.context_providers import ContextRequest, SemanticHistoryProvider
+from chapter_generation.context_models import ContextRequest
+from chapter_generation.context_providers import SemanticHistoryProvider
 from core.llm_interface import llm_service
 from data_access import chapter_queries
 from initialization.models import PlotOutline

--- a/tests/test_orchestrator_private_methods.py
+++ b/tests/test_orchestrator_private_methods.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 import utils
+from chapter_generation import ContextProfileName
 from chapter_generation.drafting_service import DraftResult
 from chapter_generation.prerequisites_service import PrerequisiteData
 from data_access import character_queries, world_queries
@@ -171,7 +172,9 @@ async def test_perform_initial_setup_sets_next_context(monkeypatch, orchestrator
     result = await orchestrator.perform_initial_setup()
 
     assert result is True
-    ctx_mock.assert_awaited_once_with(orchestrator, 1, None, None)
+    ctx_mock.assert_awaited_once_with(
+        orchestrator, 1, None, None, profile_name=ContextProfileName.DEFAULT
+    )
     assert orchestrator.next_chapter_context == "ctx0"
 
 
@@ -214,6 +217,7 @@ async def test_perform_initial_setup_loads_ch0_state(monkeypatch, orchestrator):
         1,
         None,
         {"chapter_zero_end_state": orchestrator.chapter_zero_end_state},
+        profile_name=ContextProfileName.DEFAULT,
     )
 
 
@@ -235,5 +239,7 @@ async def test_finalize_and_save_chapter_prefetches_context(orchestrator, monkey
     result = await orchestrator._finalize_and_log(1, "text", None, False)
 
     assert result == "text"
-    ctx_mock.assert_awaited_with(orchestrator, 2, None, None)
+    ctx_mock.assert_awaited_with(
+        orchestrator, 2, None, None, profile_name=ContextProfileName.DEFAULT
+    )
     assert orchestrator.next_chapter_context == "ctx1"


### PR DESCRIPTION
## Summary
- support context profiles for chapter context assembly
- enforce profile token limits in `ContextOrchestrator`
- update settings with `CONTEXT_PROFILES`
- adjust orchestrators and context generators for profiles
- test profile selection and token limits

## Testing
- `ruff check .`
- `mypy .` *(fails: Missing named argument "AGENT_LOG_LEVEL" for "SagaSettings" and other errors)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864ccb16c5c832f878f61e93863d0cc