### PR TITLE
[CORE] add plot context providers

### DIFF
--- a/chapter_generation/context_models.py
+++ b/chapter_generation/context_models.py
@@ -35,6 +35,7 @@ class ProviderSettings:
 
     provider: Any
     max_tokens: int | None = None
+    detail_level: str | None = None
 
 
 @dataclass

--- a/chapter_generation/context_orchestrator.py
+++ b/chapter_generation/context_orchestrator.py
@@ -89,12 +89,11 @@ class ContextOrchestrator:
         if profile is None:
             raise ValueError(f"Unknown context profile: {request.profile_name}")
 
-        providers = [ps.provider for ps in profile.providers]
-
         chunks: list[ContextChunk] = []
-        tasks = [provider.get_context(request) for provider in providers]
+        tasks = [ps.provider.get_context(request, ps) for ps in profile.providers]
         results = await asyncio.gather(*tasks, return_exceptions=True)
-        for provider, res in zip(providers, results, strict=True):
+        for ps, res in zip(profile.providers, results, strict=True):
+            provider = ps.provider
             if isinstance(res, Exception):  # pragma: no cover - log and skip
                 logger.warning(
                     "Context provider error", provider=provider.source, error=res


### PR DESCRIPTION
## Summary
- add provider_settings parameter and new context providers
- support chapter_limit in find_similar_chapters_in_db
- pass provider settings through ContextOrchestrator
- test PlotFocusProvider, UpcomingPlotPointsProvider, and WorldStateProvider

## Testing Done
- `ruff check .`
- `ruff format .`
- `mypy .` *(fails: Found 79 errors)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6864d127100c832f8c294b873588030a