### PR TITLE
[CORE] retry with exponential backoff

### DIFF
--- a/config.py
+++ b/config.py
@@ -78,6 +78,8 @@ class SagaSettings(BaseSettings):
     NEO4J_USER: str = "neo4j"
     NEO4J_PASSWORD: str = "saga_password"
     NEO4J_DATABASE: str | None = "neo4j"
+    NEO4J_CONNECT_RETRIES: int = 3
+    NEO4J_RETRY_DELAY_SECONDS: float = 2.0
 
     # Neo4j Vector Index Configuration
     NEO4J_VECTOR_INDEX_NAME: str = "chapterEmbeddings"


### PR DESCRIPTION
## Summary
- configure retry count and delay for Neo4j
- retry Neo4j connection with exponential backoff
- use shared backoff helper for LLM retries
- add file headers for modified modules

## Agent Changes
- n/a

## Database Changes
- none

## Configuration Changes
- `NEO4J_CONNECT_RETRIES`, `NEO4J_RETRY_DELAY_SECONDS` in `config.py`

## Testing Done
- `ruff check core/llm_interface.py core/db_manager.py config.py`
- `ruff format core/llm_interface.py core/db_manager.py config.py`
- `mypy .` *(fails: 461 errors)*
- `pytest -v --cov=.` *(fails during collection: 17 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6865a975a1e4832f8e33ce22b10ef315