### PR TITLE
[ORCHESTRATION] Refactor CLI entry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@ This file provides guidance for OpenAI Codex and other AI agents working with th
 │   ├── nana_orchestrator.py         # Primary orchestrator
 │   ├── chapter_flow.py              # Chapter generation flow
 │   ├── chapter_generation_runner.py # End-to-end runner
+│   ├── cli_runner.py                # CLI management and shutdown handling
 │   └── token_accountant.py          # Token usage tracking
 ├── processing/                      # Text processing pipeline
 │   ├── problem_parser.py            # Parse evaluation feedback
@@ -81,7 +82,7 @@ This file provides guidance for OpenAI Codex and other AI agents working with th
 ├── prompt_renderer.py               # Render prompts from templates
 ├── kg_constants.py                  # KG schema constants
 ├── config.py                        # Pydantic configuration management
-├── main.py                          # Entry point
+├── main.py                          # CLI entry that delegates to `cli_runner`
 ├── user_story_elements.yaml.example # User-provided story elements
 ├── requirements.txt                 # Python dependencies
 ├── docker-compose.yml               # Neo4j container setup

--- a/main.py
+++ b/main.py
@@ -1,51 +1,19 @@
+# main.py
+"""CLI entry point for the SAGA novel generation system."""
+
+from __future__ import annotations
+
 import argparse
-import asyncio
 
-import structlog
-from orchestration.nana_orchestrator import NANA_Orchestrator
-from utils.logging import setup_logging_nana
-
-logger = structlog.get_logger(__name__)
+from orchestration.cli_runner import run
 
 
 def main() -> None:
-    setup_logging_nana()
+    """Parse command-line arguments and start SAGA."""
     parser = argparse.ArgumentParser()
     parser.add_argument("--ingest", default=None, help="Path to text file to ingest")
     args = parser.parse_args()
-
-    orchestrator = NANA_Orchestrator()
-    try:
-        if args.ingest:
-            asyncio.run(orchestrator.run_ingestion_process(args.ingest))
-        else:
-            asyncio.run(orchestrator.run_novel_generation_loop())
-    except KeyboardInterrupt:
-        logger.info(
-            "NANA Orchestrator shutting down gracefully due to KeyboardInterrupt..."
-        )
-    except Exception as main_err:  # pragma: no cover - entry point catch
-        logger.critical(
-            "NANA Orchestrator encountered an unhandled main exception: %s",
-            main_err,
-            exc_info=True,
-        )
-    finally:
-
-        async def _shutdown() -> None:
-            await orchestrator.shutdown()
-
-        try:
-            loop = asyncio.get_running_loop()
-            if not loop.is_closed():
-                loop.create_task(_shutdown())
-        except RuntimeError:
-            asyncio.run(_shutdown())
-        except Exception as e:
-            logger.warning(
-                "Could not explicitly shutdown orchestrator from main: %s",
-                e,
-            )
+    run(args.ingest)
 
 
 if __name__ == "__main__":

--- a/orchestration/cli_runner.py
+++ b/orchestration/cli_runner.py
@@ -14,6 +14,7 @@ logger = structlog.get_logger(__name__)
 
 
 async def _run(orchestrator: NANA_Orchestrator, ingest: str | None) -> None:
+    """Dispatch to the appropriate orchestrator operation."""
     if ingest:
         await orchestrator.run_ingestion_process(ingest)
     else:

--- a/orchestration/cli_runner.py
+++ b/orchestration/cli_runner.py
@@ -1,0 +1,54 @@
+# orchestration/cli_runner.py
+"""Command-line runner for the NANA orchestrator."""
+
+from __future__ import annotations
+
+import asyncio
+
+import structlog
+from utils.logging import setup_logging_nana
+
+from orchestration.nana_orchestrator import NANA_Orchestrator
+
+logger = structlog.get_logger(__name__)
+
+
+async def _run(orchestrator: NANA_Orchestrator, ingest: str | None) -> None:
+    if ingest:
+        await orchestrator.run_ingestion_process(ingest)
+    else:
+        await orchestrator.run_novel_generation_loop()
+
+
+def run(ingest: str | None) -> None:
+    """Initialize the orchestrator and run the requested operation."""
+    setup_logging_nana()
+    orchestrator = NANA_Orchestrator()
+    try:
+        asyncio.run(_run(orchestrator, ingest))
+    except KeyboardInterrupt:
+        logger.info(
+            "NANA Orchestrator shutting down gracefully due to KeyboardInterrupt..."
+        )
+    except Exception as main_err:  # pragma: no cover - entry point catch
+        logger.critical(
+            "NANA Orchestrator encountered an unhandled main exception: %s",
+            main_err,
+            exc_info=True,
+        )
+    finally:
+
+        async def _shutdown() -> None:
+            await orchestrator.shutdown()
+
+        try:
+            loop = asyncio.get_running_loop()
+            if not loop.is_closed():
+                loop.create_task(_shutdown())
+        except RuntimeError:
+            asyncio.run(_shutdown())
+        except Exception as e:
+            logger.warning(
+                "Could not explicitly shutdown orchestrator from CLI runner: %s",
+                e,
+            )

--- a/tests/test_main_cleanup.py
+++ b/tests/test_main_cleanup.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import main
+from orchestration import cli_runner
 
 
 def test_main_invokes_shutdown(monkeypatch):
@@ -12,7 +13,7 @@ def test_main_invokes_shutdown(monkeypatch):
         shutdown=AsyncMock(),
     )
 
-    monkeypatch.setattr(main, "NANA_Orchestrator", lambda: orchestrator)
+    monkeypatch.setattr(cli_runner, "NANA_Orchestrator", lambda: orchestrator)
     monkeypatch.setattr(sys, "argv", ["prog"])
 
     main.main()


### PR DESCRIPTION
## Summary
- simplify `main.py` to only parse arguments and start the CLI runner
- move entry logic into new `orchestration.cli_runner` module
- document orchestrator module and add helper `_prepare_text_for_evaluation`
- update tests for new runner structure

## Testing Done
- `ruff check .`
- `mypy .` *(fails: Found 461 errors in 82 files)*
- `pytest -q` *(fails due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6865b1fff8a4832f976bfe6746f8fe95