### PR TITLE
[CORE] Add caching for LLM and world queries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -639,7 +639,7 @@ except Neo4jConnectionError as e:
 - **Model Selection**: Use appropriate model sizes for different tasks
 - **Context Management**: Keep prompts within `MAX_CONTEXT_TOKENS` limits
 - **Parallel Processing**: Run independent evaluations in parallel
-- **Caching**: Cache repeated LLM calls where appropriate
+- **Caching**: Cache repeated LLM calls and world queries where appropriate
 
 ### Neo4j Optimization
 - **Vector Search**: Optimize vector similarity searches with appropriate thresholds

--- a/config.py
+++ b/config.py
@@ -197,6 +197,8 @@ class SagaSettings(BaseSettings):
     KG_TRIPLE_EXTRACTION_CACHE_SIZE: int = 16
     TOKENIZER_CACHE_SIZE: int = 10
     SENTENCE_EMBEDDING_CACHE_SIZE: int = 32
+    LLM_CALL_CACHE_SIZE: int = 32
+    WORLD_QUERY_CACHE_SIZE: int = 32
 
     # Reranking Configuration
     ENABLE_RERANKING: bool = False

--- a/core/llm_interface.py
+++ b/core/llm_interface.py
@@ -383,7 +383,7 @@ class LLMService:
                 f"{prefix}{stream_prefix}LLM ('{model_name}') response missing 'usage' information or 'usage' was not a dictionary."
             )
 
-    async def async_call_llm(
+    async def _async_call_llm(
         self,
         model_name: str,
         prompt: str,
@@ -785,6 +785,31 @@ class LLMService:
                 final_text_response = self.clean_model_response(final_text_response)
 
             return final_text_response, current_usage_data
+
+    @alru_cache(maxsize=settings.LLM_CALL_CACHE_SIZE)
+    async def async_call_llm(
+        self,
+        model_name: str,
+        prompt: str,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        allow_fallback: bool = False,
+        stream_to_disk: bool = False,
+        frequency_penalty: float | None = None,
+        presence_penalty: float | None = None,
+        auto_clean_response: bool = True,
+    ) -> tuple[str, dict[str, int] | None]:
+        return await self._async_call_llm(
+            model_name=model_name,
+            prompt=prompt,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            allow_fallback=allow_fallback,
+            stream_to_disk=stream_to_disk,
+            frequency_penalty=frequency_penalty,
+            presence_penalty=presence_penalty,
+            auto_clean_response=auto_clean_response,
+        )
 
     def clean_model_response(self, text: str) -> str:
         """Cleans common artifacts from LLM text responses, including content within <think> tags and normalizes newlines."""

--- a/data_access/character_queries.py
+++ b/data_access/character_queries.py
@@ -469,8 +469,8 @@ async def get_character_profiles_from_db(
       WHERE $limit IS NULL OR dev.{KG_NODE_CHAPTER_UPDATED} <= $limit
     RETURN c,
            collect(DISTINCT tr.name) AS traits,
-           collect(DISTINCT {target: target.name, props: properties(r)}) AS rels,
-           collect(DISTINCT {chapter: dev.{KG_NODE_CHAPTER_UPDATED}, summary: dev.summary, prov: dev.{KG_IS_PROVISIONAL}}) AS devs
+           collect(DISTINCT {{target: target.name, props: properties(r)}}) AS rels,
+           collect(DISTINCT {{chapter: dev.{KG_NODE_CHAPTER_UPDATED}, summary: dev.summary, prov: dev.{KG_IS_PROVISIONAL}}}) AS devs
     """
 
     results = await neo4j_manager.execute_read_query(query, params or None)

--- a/data_access/world_queries.py
+++ b/data_access/world_queries.py
@@ -567,6 +567,7 @@ async def get_all_world_item_ids_by_category() -> dict[str, list[str]]:
     return mapping
 
 
+@alru_cache(maxsize=settings.WORLD_QUERY_CACHE_SIZE)
 async def get_world_building_from_db(
     chapter_limit: int | None = None,
 ) -> dict[str, dict[str, WorldItem]]:


### PR DESCRIPTION
## Summary
- cache LLM responses to avoid redundant API calls
- cache world-building queries to reduce database load
- fix formatting of a Cypher query
- document caching of world queries
- configure cache sizes in settings

## Testing
- `ruff check .`
- `mypy .` *(fails: Library stubs not installed & many typing errors)*
- `pytest -v --cov=.` *(fails: ImportError during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_6865c200852c832fa35443d645210816