### PR TITLE
[TESTS] ensure revision loop cap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -437,6 +437,8 @@ async def generate_agent_response(
 - **Problem Grouping**: Group related evaluation problems for efficient patching
 - **Validation**: Use `PatchValidationAgent` when `AGENT_ENABLE_PATCH_VALIDATION` is enabled
 - **Full Rewrite Fallback**: Trigger complete rewrite when patching is insufficient
+- **Cycle Limit**: Respect `MAX_REVISION_CYCLES_PER_CHAPTER` to avoid infinite revision loops
+- **Evaluation & Revision Loop**: `EvaluationService` reports issues and `RevisionService` applies fixes. Re-evaluate after each cycle to ensure new problems aren't introduced.
 
 ### Text Processing
 - **De-duplication**: Apply text de-duplication before evaluation


### PR DESCRIPTION
## Summary
- document revision cycle limit and evaluation loop interaction
- test that revision loop stops after configured maximum

## Testing Done
- `ruff check .`
- `mypy .` *(fails: numerous type errors)*
- `pytest -vv tests/test_revision_loop.py::test_revision_loop_respects_max_cycles` *(fails: ImportError for kg_maintainer.parsing)*

------
https://chatgpt.com/codex/tasks/task_e_6865c84a4a08832fafc99043a193beda