### PR TITLE
[CORE] fix missing module exports

### DIFF
--- a/data_access/__init__.py
+++ b/data_access/__init__.py
@@ -22,10 +22,13 @@ from .character_queries import (
 )
 from .kg_queries import (
     add_kg_triples_batch_to_db,
+    fetch_unresolved_dynamic_relationships,
     get_most_recent_value_from_db,
     get_novel_info_property_from_db,
+    get_shortest_path_length_between_entities,
     normalize_existing_relationship_types,
     query_kg_from_db,
+    update_dynamic_relationship_type,
 )
 from .plot_queries import (
     append_plot_point,

--- a/kg_maintainer/__init__.py
+++ b/kg_maintainer/__init__.py
@@ -1,9 +1,20 @@
+# kg_maintainer/__init__.py
 """Package consolidating KG maintainer utilities."""
 
+import importlib
+
+from parsing import (
+    __name__ as _parsing_name,
+)
 from parsing import (
     parse_unified_character_updates,
     parse_unified_world_updates,
 )
+
+from . import merge as merge
+from . import models as models
+
+parsing = importlib.import_module(_parsing_name)
 
 from .merge import (
     merge_character_profile_updates,
@@ -31,4 +42,7 @@ __all__ = [
     "parse_unified_world_updates",
     "merge_character_profile_updates",
     "merge_world_item_updates",
+    "merge",
+    "models",
+    "parsing",
 ]


### PR DESCRIPTION
## Summary
- expose parsing as submodule via `kg_maintainer/__init__.py`
- import Neo4j helper functions in `data_access/__init__.py`

## Testing Done
- `ruff check .`
- `ruff format .`
- `mypy .` *(fails: missing type hints)*
- `pytest -q` *(fails: test_get_world_building_runs_healer)*

------
https://chatgpt.com/codex/tasks/task_e_6865cb68bbd0832f82dd1beb75eebc81