### PR TITLE
[CORE] fix missing limit parameter

### DIFF
--- a/data_access/character_queries.py
+++ b/data_access/character_queries.py
@@ -452,11 +452,10 @@ async def get_character_profiles_from_db(
     )
     profiles_data: dict[str, CharacterProfile] = {}
 
-    params: dict[str, Any] = {}
+    params: dict[str, Any] = {"limit": chapter_limit}
     chapter_filter = ""
     if chapter_limit is not None:
         chapter_filter = f"AND (c.{KG_NODE_CHAPTER_UPDATED} IS NULL OR c.{KG_NODE_CHAPTER_UPDATED} <= $limit)"
-        params["limit"] = chapter_limit
 
     query = f"""
     MATCH (c:Character:Entity)
@@ -473,7 +472,7 @@ async def get_character_profiles_from_db(
            collect(DISTINCT {{chapter: dev.{KG_NODE_CHAPTER_UPDATED}, summary: dev.summary, prov: dev.{KG_IS_PROVISIONAL}}}) AS devs
     """
 
-    results = await neo4j_manager.execute_read_query(query, params or None)
+    results = await neo4j_manager.execute_read_query(query, params)
 
     for record in results:
         char_node = record.get("c")

--- a/data_access/world_queries.py
+++ b/data_access/world_queries.py
@@ -613,11 +613,10 @@ async def get_world_building_from_db(
             utils._normalize_for_id("_overview_")  # Should be wc_id_param
         )
 
-    we_params: dict[str, Any] = {}
+    we_params: dict[str, Any] = {"limit": chapter_limit}
     chapter_filter = ""
     if chapter_limit is not None:
         chapter_filter = f"AND (we.{KG_NODE_CREATED_CHAPTER} IS NULL OR we.{KG_NODE_CREATED_CHAPTER} <= $limit)"
-        we_params["limit"] = chapter_limit
 
     query = f"""
     MATCH (we:WorldElement:Entity)
@@ -638,7 +637,7 @@ async def get_world_building_from_db(
     ORDER BY we.category, we.name
     """
 
-    we_results = await neo4j_manager.execute_read_query(query, we_params or None)
+    we_results = await neo4j_manager.execute_read_query(query, we_params)
 
     if not we_results:
         logger.info(


### PR DESCRIPTION
## Summary
- ensure optional limit parameters are passed to Neo4j queries

## Testing Done
- `ruff check data_access/character_queries.py data_access/world_queries.py`
- `ruff format --check data_access/character_queries.py data_access/world_queries.py`
- `mypy data_access/character_queries.py data_access/world_queries.py` *(fails: Missing named argument "AGENT_LOG_LEVEL" and others)*
- `pytest tests/test_world_healing.py::test_get_world_building_runs_healer -q`

------
https://chatgpt.com/codex/tasks/task_e_6865d735bdb4832f835071dcf9ebd7ab