### PR TITLE
[ORCHESTRATION] enrich hybrid context with KG lookups

### DIFF
--- a/orchestration/nana_orchestrator.py
+++ b/orchestration/nana_orchestrator.py
@@ -961,6 +961,10 @@ class NANA_Orchestrator:
                 chapter_plan,
                 None,
                 profile_name=ContextProfileName.DEFAULT,
+                missing_entities=list(
+                    self.missing_references["characters"]
+                    | self.missing_references["locations"]
+                ),
             )
         else:
             self.next_chapter_context = None


### PR DESCRIPTION
## Summary
- look up missing entity facts when building hybrid context
- include KG details in the final context
- query helper functions for missing entity info
- test missing entity lookup path

## Testing Done
- `ruff format .`
- `ruff check .`
- `mypy .` *(fails: Library stubs not installed for `yaml`; some tests lack type hints)*
- `pytest -v --cov=.`

------
https://chatgpt.com/codex/tasks/task_e_6865fce95968832fb58a2b7c66dfd1c1