### PR TITLE
[AGENT] handle fill-ins in finalization

### DIFF
--- a/agents/finalize_agent.py
+++ b/agents/finalize_agent.py
@@ -37,6 +37,7 @@ class FinalizeAgent:
         chapter_number: int,
         chapter_text: str,
         from_flawed_draft: bool,
+        fill_in_context: str | None,
     ) -> dict[str, int] | None:
         return await self.kg_agent.extract_and_merge_knowledge(
             plot_outline,
@@ -45,6 +46,7 @@ class FinalizeAgent:
             chapter_number,
             chapter_text,
             is_from_flawed_draft=from_flawed_draft,
+            fill_in_context=fill_in_context,
         )
 
     async def finalize_chapter(
@@ -56,6 +58,7 @@ class FinalizeAgent:
         final_text: str,
         raw_llm_output: str | None = None,
         from_flawed_draft: bool = False,
+        fill_in_context: str | None = None,
     ) -> FinalizationResult:
         """Finalize a chapter and persist all related updates.
 
@@ -67,6 +70,8 @@ class FinalizeAgent:
             final_text: The approved chapter text.
             raw_llm_output: Optional raw draft from the LLM.
             from_flawed_draft: Whether the text came from a flawed draft.
+            fill_in_context: Additional context filled in by LLMs for missing
+                references.
 
         Returns:
             A dictionary containing the summary, embedding, and token usage data.
@@ -80,9 +85,12 @@ class FinalizeAgent:
             chapter_number,
             final_text,
             from_flawed_draft,
+            fill_in_context,
         )
         end_state_task = self.kg_agent.generate_chapter_end_state(
-            final_text, chapter_number
+            final_text,
+            chapter_number,
+            fill_in_context=fill_in_context,
         )
 
         (summary_data, embedding, kg_usage, end_state) = await asyncio.gather(

--- a/chapter_generation/finalization_service.py
+++ b/chapter_generation/finalization_service.py
@@ -34,6 +34,7 @@ class FinalizationService:
         final_text: str,
         raw_llm_output: str | None,
         from_flawed_draft: bool,
+        fill_in_context: str | None,
     ) -> FinalizationServiceResult:
         """Return persisted chapter details."""
 
@@ -45,5 +46,6 @@ class FinalizationService:
             final_text,
             raw_llm_output,
             from_flawed_draft,
+            fill_in_context,
         )
         return FinalizationServiceResult(text=final_text)

--- a/chapter_generation/prerequisites_service.py
+++ b/chapter_generation/prerequisites_service.py
@@ -1,3 +1,4 @@
+# chapter_generation/prerequisites_service.py
 """Gather required planning and context before drafting."""
 
 from __future__ import annotations
@@ -15,3 +16,4 @@ class PrerequisiteData:
     plot_point_index: int
     chapter_plan: list[SceneDetail] | None
     hybrid_context_for_draft: str | None
+    fill_in_context: str | None = None

--- a/orchestration/chapter_flow.py
+++ b/orchestration/chapter_flow.py
@@ -1,3 +1,4 @@
+# orchestration/chapter_flow.py
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -29,6 +30,7 @@ async def run_chapter_pipeline(
     plot_point_index = processed_prereqs.plot_point_index
     chapter_plan = processed_prereqs.chapter_plan
     hybrid_context_for_draft = processed_prereqs.hybrid_context_for_draft
+    fill_in_context = processed_prereqs.fill_in_context
 
     draft_result = await orchestrator._draft_initial_chapter_text(
         novel_chapter_number,
@@ -63,5 +65,9 @@ async def run_chapter_pipeline(
     is_flawed = processed_revision.is_flawed
 
     return await orchestrator._finalize_and_log(
-        novel_chapter_number, processed_text, processed_raw_llm, is_flawed
+        novel_chapter_number,
+        processed_text,
+        processed_raw_llm,
+        is_flawed,
+        fill_in_context,
     )

--- a/orchestration/service_layer.py
+++ b/orchestration/service_layer.py
@@ -116,6 +116,7 @@ class ChapterServiceLayer:
         final_text: str,
         raw_llm_output: str | None,
         from_flawed_draft: bool,
+        fill_in_context: str | None,
     ) -> FinalizationServiceResult:
         """Finalize and persist chapter output."""
         return await self.finalization_service.finalize(
@@ -126,4 +127,5 @@ class ChapterServiceLayer:
             final_text,
             raw_llm_output,
             from_flawed_draft,
+            fill_in_context,
         )

--- a/prompts/kg_maintainer_agent/chapter_end_state.j2
+++ b/prompts/kg_maintainer_agent/chapter_end_state.j2
@@ -37,4 +37,8 @@ Chapter text to analyze:
 """
 {{ chapter_text }}
 """
+{% if fill_in_context %}
+Additional provisional context:
+{{ fill_in_context }}
+{% endif %}
 

--- a/prompts/kg_maintainer_agent/extract_updates.j2
+++ b/prompts/kg_maintainer_agent/extract_updates.j2
@@ -32,6 +32,11 @@ You are an expert knowledge graph extractor for a creative writing project. Anal
 {{ chapter_text }}
 ```
 ---
+{% if fill_in_context %}
+Additional provisional context:
+{{ fill_in_context }}
+---
+{% endif %}
 
 **Ignore the narrative details in the below example. It shows the required format only.**
 **Example of Final JSON Output Structure:**

--- a/tests/test_agent_extract.py
+++ b/tests/test_agent_extract.py
@@ -1,4 +1,6 @@
+# tests/test_agent_extract.py
 import asyncio
+from typing import Any
 
 import pytest
 from agents.kg_maintainer_agent import KGMaintainerAgent
@@ -16,7 +18,7 @@ class DummyLLM:
 llm_service_mock = DummyLLM()
 
 
-def test_extract_and_merge(monkeypatch):
+def test_extract_and_merge(monkeypatch) -> None:
     agent = KGMaintainerAgent()
     monkeypatch.setattr(
         agent,
@@ -49,8 +51,37 @@ def test_extract_and_merge(monkeypatch):
     assert character_profiles["Alice"].traits == ["brave"]
 
 
+def test_extract_with_fill_ins(monkeypatch) -> None:
+    agent = KGMaintainerAgent()
+    monkeypatch.setattr(
+        agent,
+        "_llm_extract_updates",
+        lambda *a, **k: llm_service_mock.async_call_llm(),
+    )
+    called: dict[str, Any] = {}
+
+    async def fake_add(triples, chapter, provisional):
+        called["provisional"] = provisional
+
+    monkeypatch.setattr("data_access.kg_queries.add_kg_triples_batch_to_db", fake_add)
+    monkeypatch.setattr(agent, "persist_profiles", lambda *a, **k: asyncio.sleep(0))
+    monkeypatch.setattr(agent, "persist_world", lambda *a, **k: asyncio.sleep(0))
+
+    asyncio.run(
+        agent.extract_and_merge_knowledge(
+            {},
+            {},
+            {},
+            1,
+            "text",
+            fill_in_context="extra",
+        )
+    )
+    assert called.get("provisional") is True
+
+
 @pytest.mark.asyncio
-async def test_summarize_chapter_json(monkeypatch):
+async def test_summarize_chapter_json(monkeypatch) -> None:
     agent = KGMaintainerAgent()
 
     async def _fake_llm(*args, **kwargs):

--- a/tests/test_chapter_flow.py
+++ b/tests/test_chapter_flow.py
@@ -1,3 +1,4 @@
+# tests/test_chapter_flow.py
 import pytest
 from chapter_generation.drafting_service import DraftResult
 from chapter_generation.prerequisites_service import PrerequisiteData
@@ -18,7 +19,7 @@ class DummyOrchestrator:
     async def _prepare_chapter_prerequisites(self, chapter):
         return self.values.get(
             "prereq",
-            PrerequisiteData("focus", 1, "plan", "ctx"),
+            PrerequisiteData("focus", 1, "plan", "ctx", None),
         )
 
     async def _process_prereq_result(self, chapter, prereq_result):
@@ -47,14 +48,14 @@ class DummyOrchestrator:
 
 
 @pytest.mark.asyncio
-async def test_run_chapter_pipeline_success():
+async def test_run_chapter_pipeline_success() -> None:
     orch = DummyOrchestrator()
     result = await chapter_flow.run_chapter_pipeline(orch, 1)
     assert result == "done"
 
 
 @pytest.mark.asyncio
-async def test_run_chapter_pipeline_invalid_outline():
+async def test_run_chapter_pipeline_invalid_outline() -> None:
     orch = DummyOrchestrator()
     orch.values["validate"] = False
     result = await chapter_flow.run_chapter_pipeline(orch, 1)
@@ -62,7 +63,7 @@ async def test_run_chapter_pipeline_invalid_outline():
 
 
 @pytest.mark.asyncio
-async def test_run_chapter_pipeline_prereq_none():
+async def test_run_chapter_pipeline_prereq_none() -> None:
     orch = DummyOrchestrator()
     orch.values["process_prereqs"] = None
     result = await chapter_flow.run_chapter_pipeline(orch, 1)
@@ -70,7 +71,7 @@ async def test_run_chapter_pipeline_prereq_none():
 
 
 @pytest.mark.asyncio
-async def test_run_chapter_pipeline_draft_none():
+async def test_run_chapter_pipeline_draft_none() -> None:
     orch = DummyOrchestrator()
     orch.values["process_draft"] = None
     result = await chapter_flow.run_chapter_pipeline(orch, 1)
@@ -78,7 +79,7 @@ async def test_run_chapter_pipeline_draft_none():
 
 
 @pytest.mark.asyncio
-async def test_run_chapter_pipeline_revision_none():
+async def test_run_chapter_pipeline_revision_none() -> None:
     orch = DummyOrchestrator()
     orch.values["process_revision"] = None
     result = await chapter_flow.run_chapter_pipeline(orch, 1)

--- a/tests/test_orchestrator_private_methods.py
+++ b/tests/test_orchestrator_private_methods.py
@@ -36,27 +36,27 @@ def orchestrator(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_validate_plot_outline_missing(orchestrator):
+async def test_validate_plot_outline_missing(orchestrator) -> None:
     orchestrator.plot_outline = PlotOutline()
     assert not await orchestrator._validate_plot_outline(1)
 
 
 @pytest.mark.asyncio
-async def test_process_prereq_result_failure(orchestrator):
+async def test_process_prereq_result_failure(orchestrator) -> None:
     result = await orchestrator._process_prereq_result(
-        1, PrerequisiteData(None, -1, None, None)
+        1, PrerequisiteData(None, -1, None, None, None)
     )
     assert result is None
 
 
 @pytest.mark.asyncio
-async def test_process_initial_draft_failure(orchestrator):
+async def test_process_initial_draft_failure(orchestrator) -> None:
     result = await orchestrator._process_initial_draft(1, DraftResult(None, None))
     assert result is None
 
 
 @pytest.mark.asyncio
-async def test_process_revision_result_failure(orchestrator):
+async def test_process_revision_result_failure(orchestrator) -> None:
     result = await orchestrator._process_revision_result(
         1, RevisionOutcome(None, None, False)
     )
@@ -64,7 +64,7 @@ async def test_process_revision_result_failure(orchestrator):
 
 
 @pytest.mark.asyncio
-async def test_finalize_and_log_success(orchestrator, monkeypatch):
+async def test_finalize_and_log_success(orchestrator, monkeypatch) -> None:
     monkeypatch.setattr(
         orchestrator,
         "_finalize_and_save_chapter",
@@ -75,7 +75,7 @@ async def test_finalize_and_log_success(orchestrator, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_finalize_and_log_failure(orchestrator, monkeypatch):
+async def test_finalize_and_log_failure(orchestrator, monkeypatch) -> None:
     monkeypatch.setattr(
         orchestrator,
         "_finalize_and_save_chapter",
@@ -97,7 +97,7 @@ def test_load_state_from_user_model(orchestrator):
 
 
 @pytest.mark.asyncio
-async def test_prepare_prerequisites_uses_plan(orchestrator, monkeypatch):
+async def test_prepare_prerequisites_uses_plan(orchestrator, monkeypatch) -> None:
     orchestrator.plot_outline = PlotOutline(plot_points=["Intro"])
     orchestrator.next_chapter_context = "prefetched"
     monkeypatch.setattr(orchestrator, "_update_novel_props_cache", lambda: None)
@@ -149,13 +149,16 @@ async def test_prepare_prerequisites_uses_plan(orchestrator, monkeypatch):
         plot_point_index=0,
         chapter_plan=[{"scene_number": 1}],
         hybrid_context_for_draft="prefetched",
+        fill_in_context=None,
     )
     assert orchestrator.next_chapter_context is None
     build_ctx_mock.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_perform_initial_setup_sets_next_context(monkeypatch, orchestrator):
+async def test_perform_initial_setup_sets_next_context(
+    monkeypatch, orchestrator
+) -> None:
     plot_outline = PlotOutline(title="T", plot_points=["p"], protagonist_name="Hero")
     monkeypatch.setattr(
         "orchestration.nana_orchestrator.run_genesis_phase",
@@ -179,7 +182,7 @@ async def test_perform_initial_setup_sets_next_context(monkeypatch, orchestrator
 
 
 @pytest.mark.asyncio
-async def test_perform_initial_setup_loads_ch0_state(monkeypatch, orchestrator):
+async def test_perform_initial_setup_loads_ch0_state(monkeypatch, orchestrator) -> None:
     plot_outline = PlotOutline(title="T", plot_points=["p"], protagonist_name="Hero")
     monkeypatch.setattr(
         "orchestration.nana_orchestrator.run_genesis_phase",


### PR DESCRIPTION
## Summary
- pass fill-in context through the chapter finalization flow
- treat fill-ins as provisional when merging into the KG
- include fill-in text in prompts for KG extraction and chapter state
- update orchestrator pipeline to track fill-in context
- expand unit tests for new fill-in handling

## Agent Changes
- FinalizeAgent uses KGMaintainerAgent with fill-in context
- Orchestrator methods forward provisional context

## Database Changes
- none

## Configuration Changes
- none

## Testing Done
- `ruff check . && mypy .` *(fails: several type errors)*
- `pytest -q` *(fails: pytest cannot run with coverage arguments)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68661020e4ec832f9659fef60a8136d8