### PR TITLE
[ORCHESTRATION] queue fill-ins and state for next run

### DIFF
--- a/agents/finalize_agent.py
+++ b/agents/finalize_agent.py
@@ -10,7 +10,7 @@ from core.llm_interface import llm_service
 from data_access import chapter_repository
 
 from agents.kg_maintainer_agent import KGMaintainerAgent
-from models import CharacterProfile, WorldItem
+from models import ChapterEndState, CharacterProfile, WorldItem
 
 logger = structlog.get_logger(__name__)
 
@@ -20,6 +20,7 @@ class FinalizationResult(TypedDict, total=False):
     embedding: np.ndarray | None
     summary_usage: dict[str, int] | None
     kg_usage: dict[str, int] | None
+    chapter_end_state: ChapterEndState | None
 
 
 class FinalizeAgent:
@@ -113,6 +114,7 @@ class FinalizeAgent:
             "embedding": embedding,
             "summary_usage": summary_usage,
             "kg_usage": kg_usage,
+            "chapter_end_state": end_state,
         }
 
     async def ingest_and_finalize_chunk(

--- a/tests/test_finalize_agent.py
+++ b/tests/test_finalize_agent.py
@@ -66,6 +66,7 @@ async def test_finalize_chapter_success(monkeypatch) -> None:
     assert result["summary"] == "sum"
     assert np.allclose(result["embedding"], np.array([0.1, 0.2], dtype=np.float32))
     assert result["kg_usage"] == {"total_tokens": 2}
+    assert isinstance(result["chapter_end_state"], ChapterEndState)
 
 
 @pytest.mark.asyncio
@@ -126,6 +127,7 @@ async def test_finalize_chapter_validation_failure(monkeypatch) -> None:
     assert profiles_called == {}
     assert world_called == {}
     assert result["kg_usage"] == {"total_tokens": 2}
+    assert isinstance(result["chapter_end_state"], ChapterEndState)
 
 
 @pytest.mark.asyncio
@@ -164,5 +166,6 @@ async def test_finalize_chapter_passes_fill_ins(monkeypatch) -> None:
         lambda *a, **k: asyncio.Future(),
     )
 
-    await agent.finalize_chapter({}, {}, {}, 1, "t", fill_in_context="extra")
+    result = await agent.finalize_chapter({}, {}, {}, 1, "t", fill_in_context="extra")
     assert captured.get("fill_in_context") == "extra"
+    assert isinstance(result["chapter_end_state"], ChapterEndState)


### PR DESCRIPTION
## Summary
- combine pending and current fill-ins when finalizing
- pass latest end state as hint for building next context
- fold pending fill-ins into next chapter prerequisites
- allow state provider to use supplied previous end state
- test handling of pending fill-ins

## Testing
- `ruff check .`
- `mypy .` *(fails: tests have numerous type issues)*
- `pytest` *(fails: pytest-cov arguments unsupported)*

------
https://chatgpt.com/codex/tasks/task_e_686618207668832fb9d9150102c70038