### PR TITLE
[ORCHESTRATION] extract output and prereq services

### DIFF
--- a/orchestration/knowledge_service.py
+++ b/orchestration/knowledge_service.py
@@ -1,0 +1,114 @@
+# orchestration/knowledge_service.py
+"""Service for managing plot and knowledge caches."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import structlog
+from config import settings
+from data_access import (
+    chapter_repository,
+    character_queries,
+    plot_queries,
+    world_queries,
+)
+from initialization.models import PlotOutline
+
+from orchestration.token_accountant import Stage
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints
+    from .nana_orchestrator import NANA_Orchestrator
+
+logger = structlog.get_logger(__name__)
+
+
+class KnowledgeService:
+    """Handle plot outline and knowledge cache operations."""
+
+    def __init__(self, orchestrator: NANA_Orchestrator) -> None:
+        self.orchestrator = orchestrator
+
+    def update_novel_props_cache(self) -> None:
+        """Refresh novel property cache from the current plot outline."""
+        o = self.orchestrator
+        o.novel_props_cache = {
+            "title": o.plot_outline.get("title", settings.DEFAULT_PLOT_OUTLINE_TITLE),
+            "genre": o.plot_outline.get("genre", settings.CONFIGURED_GENRE),
+            "theme": o.plot_outline.get("theme", settings.CONFIGURED_THEME),
+            "protagonist_name": o.plot_outline.get(
+                "protagonist_name", settings.DEFAULT_PROTAGONIST_NAME
+            ),
+            "character_arc": o.plot_outline.get("character_arc", "N/A"),
+            "logline": o.plot_outline.get("logline", "N/A"),
+            "setting": o.plot_outline.get(
+                "setting", settings.CONFIGURED_SETTING_DESCRIPTION
+            ),
+            "narrative_style": o.plot_outline.get("narrative_style", "N/A"),
+            "tone": o.plot_outline.get("tone", "N/A"),
+            "pacing": o.plot_outline.get("pacing", "N/A"),
+            "plot_points": o.plot_outline.get("plot_points", []),
+            "plot_outline_full": o.plot_outline,
+        }
+        o._update_rich_display()
+
+    async def refresh_plot_outline(self) -> None:
+        """Reload the plot outline from the database."""
+        result = await plot_queries.get_plot_outline_from_db()
+        if isinstance(result, dict):
+            self.orchestrator.plot_outline = PlotOutline(**result)
+            self.update_novel_props_cache()
+            self.orchestrator.completed_plot_points = set(
+                await plot_queries.get_completed_plot_points()
+            )
+        else:
+            logger.error("Failed to refresh plot outline from DB: %s", result)
+
+    async def refresh_knowledge_cache(self) -> None:
+        """Reload character and world knowledge from the database."""
+        o = self.orchestrator
+        logger.info("Refreshing knowledge cache from Neo4j...")
+        o.knowledge_cache.characters = (
+            await character_queries.get_character_profiles_from_db()
+        )
+        o.knowledge_cache.world = await world_queries.get_world_building_from_db()
+        logger.info(
+            "Knowledge cache refreshed: %d characters, %d world categories.",
+            len(o.knowledge_cache.characters),
+            len(o.knowledge_cache.world),
+        )
+
+    async def generate_plot_points_from_kg(self, count: int) -> None:
+        """Create additional plot points using the planner agent."""
+        o = self.orchestrator
+        if count <= 0:
+            return
+
+        summaries: list[str] = []
+        start = max(1, o.chapter_count - settings.CONTEXT_CHAPTER_COUNT + 1)
+        for i in range(start, o.chapter_count + 1):
+            chap = await chapter_repository.get_chapter_data(i)
+            if chap and (chap.get("summary") or chap.get("text")):
+                summaries.append((chap.get("summary") or chap.get("text", "")).strip())
+
+        combined_summary = "\n".join(summaries)
+        if not combined_summary.strip():
+            logger.warning("No summaries available for continuation planning.")
+            return
+
+        new_points, usage = await o.planner_agent.plan_continuation(
+            combined_summary, count
+        )
+        o._accumulate_tokens(Stage.PLAN_CONTINUATION.value, usage)
+        if not new_points:
+            logger.error("Failed to generate continuation plot points.")
+            return
+
+        for desc in new_points:
+            if await plot_queries.plot_point_exists(desc):
+                logger.info("Plot point already exists, skipping: %s", desc)
+                continue
+            prev_id = await plot_queries.get_last_plot_point_id()
+            await o.kg_maintainer_agent.add_plot_point(desc, prev_id or "")
+            o.plot_outline.setdefault("plot_points", []).append(desc)
+        self.update_novel_props_cache()

--- a/orchestration/models.py
+++ b/orchestration/models.py
@@ -1,0 +1,23 @@
+# orchestration/models.py
+"""Shared dataclasses for orchestration services."""
+
+from dataclasses import dataclass, field
+
+from kg_maintainer.models import CharacterProfile, WorldItem
+
+
+@dataclass
+class RevisionOutcome:
+    """Final text after processing and whether it is marked flawed."""
+
+    text: str | None
+    raw_llm_output: str | None
+    is_flawed: bool
+
+
+@dataclass
+class KnowledgeCache:
+    """In-memory cache for KG data used during chapter generation."""
+
+    characters: dict[str, CharacterProfile] = field(default_factory=dict)
+    world: dict[str, dict[str, WorldItem]] = field(default_factory=dict)

--- a/orchestration/output_service.py
+++ b/orchestration/output_service.py
@@ -1,0 +1,130 @@
+# orchestration/output_service.py
+"""Service for persisting chapter outputs and debug logs."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import structlog
+from agents.finalize_agent import FinalizationResult
+from data_access import character_queries, world_queries
+from kg_maintainer.models import ChapterEndState
+from storage.file_manager import FileManager
+
+from orchestration.token_accountant import Stage
+
+if TYPE_CHECKING:  # pragma: no cover - type hints
+    from .nana_orchestrator import NANA_Orchestrator
+
+logger = structlog.get_logger(__name__)
+
+
+class OutputService:
+    """Handle finalization, file output and debug logging."""
+
+    def __init__(self, orchestrator: NANA_Orchestrator) -> None:
+        self.orchestrator = orchestrator
+        self.file_manager: FileManager = orchestrator.file_manager
+
+    async def save_chapter_text_and_log(
+        self, chapter_number: int, final_text: str, raw_llm_log: str | None
+    ) -> None:
+        """Persist final chapter text and raw LLM output."""
+        try:
+            await self.file_manager.save_chapter_and_log(
+                chapter_number, final_text, raw_llm_log or "N/A"
+            )
+            logger.info(
+                "Saved chapter text and raw LLM log files for ch %s.", chapter_number
+            )
+        except OSError as exc:
+            logger.error(
+                "Failed writing chapter text/log files for ch %s: %s",
+                chapter_number,
+                exc,
+                exc_info=True,
+            )
+
+    async def save_debug_output(
+        self, chapter_number: int, stage_description: str, content: Any
+    ) -> None:
+        """Write debug data to disk if content is provided."""
+        if content is None:
+            return
+        content_str = str(content) if not isinstance(content, str) else content
+        if not content_str.strip():
+            return
+        try:
+            await self.file_manager.save_debug_output(
+                chapter_number, stage_description, content_str
+            )
+            logger.debug(
+                "Saved debug output for Ch %s, Stage '%s'",
+                chapter_number,
+                stage_description,
+            )
+        except Exception as exc:  # pragma: no cover - log and continue
+            logger.error(
+                "Failed to save debug output (Ch %s, Stage '%s'): %s",
+                chapter_number,
+                stage_description,
+                exc,
+                exc_info=True,
+            )
+
+    async def finalize_and_save_chapter(
+        self,
+        novel_chapter_number: int,
+        final_text: str,
+        final_raw_llm_output: str | None,
+        is_from_flawed_source_for_kg: bool,
+        fill_in_context: str | None,
+    ) -> tuple[str | None, ChapterEndState | None]:
+        """Finalize a chapter, persist all files and update counters."""
+        o = self.orchestrator
+        o._update_rich_display(step=f"Ch {novel_chapter_number} - Finalization")
+
+        result: FinalizationResult = await o.finalize_agent.finalize_chapter(
+            o.plot_outline,
+            await character_queries.get_character_profiles_from_db(),
+            await world_queries.get_world_building_from_db(),
+            novel_chapter_number,
+            final_text,
+            final_raw_llm_output,
+            is_from_flawed_source_for_kg,
+            fill_in_context=fill_in_context,
+        )
+
+        o._accumulate_tokens(
+            f"Ch{novel_chapter_number}-{Stage.SUMMARIZATION.value}",
+            result.get("summary_usage"),
+        )
+        o._accumulate_tokens(
+            f"Ch{novel_chapter_number}-{Stage.KG_EXTRACTION_MERGE.value}",
+            result.get("kg_usage"),
+        )
+        await self.save_debug_output(
+            novel_chapter_number, "final_summary", result.get("summary")
+        )
+
+        if result.get("embedding") is None:
+            logger.error(
+                "NANA CRITICAL: Failed to generate embedding for final text of Chapter %s. Text saved to file system only.",
+                novel_chapter_number,
+            )
+            await self.save_chapter_text_and_log(
+                novel_chapter_number, final_text, final_raw_llm_output
+            )
+            o._update_rich_display(
+                step=f"Ch {novel_chapter_number} Failed - No Embedding"
+            )
+            return None, result.get("chapter_end_state")
+
+        await self.save_chapter_text_and_log(
+            novel_chapter_number, final_text, final_raw_llm_output
+        )
+
+        o.repetition_tracker.update_from_text(final_text)
+        o.chapter_count = max(o.chapter_count, novel_chapter_number)
+
+        return final_text, result.get("chapter_end_state")

--- a/orchestration/prerequisite_service.py
+++ b/orchestration/prerequisite_service.py
@@ -1,0 +1,170 @@
+# orchestration/prerequisite_service.py
+"""Service for gathering chapter prerequisites."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import structlog
+from chapter_generation.context_models import ContextProfileName, SceneDetail
+from chapter_generation.prerequisites_service import PrerequisiteData
+from config import settings
+from core.db_manager import neo4j_manager
+from utils.plot import get_plot_point_info
+
+from orchestration.token_accountant import Stage
+
+if TYPE_CHECKING:  # pragma: no cover - type hints
+    from .nana_orchestrator import NANA_Orchestrator
+
+logger = structlog.get_logger(__name__)
+
+
+class PrerequisiteService:
+    """Generate planning context and scene plans."""
+
+    def __init__(self, orchestrator: NANA_Orchestrator) -> None:
+        self.orchestrator = orchestrator
+
+    async def gather(self, novel_chapter_number: int) -> PrerequisiteData:
+        """Return planning data required before drafting."""
+        o = self.orchestrator
+        o._update_rich_display(
+            step=f"Ch {novel_chapter_number} - Preparing Prerequisites"
+        )
+
+        plot_point_focus, plot_point_index = get_plot_point_info(
+            o.plot_outline, novel_chapter_number
+        )
+        if plot_point_focus is None:
+            logger.error(
+                "NANA: Ch %s prerequisite check failed: no concrete plot point focus (index %s).",
+                novel_chapter_number,
+                plot_point_index,
+            )
+            return PrerequisiteData(None, -1, None, None)
+
+        o._update_novel_props_cache()
+
+        planning_context = o.next_chapter_context
+        if planning_context is None:
+            planning_context = await o.context_service.build_hybrid_context(
+                o,
+                novel_chapter_number,
+                None,
+                None,
+                profile_name=ContextProfileName.DEFAULT,
+            )
+        chapter_plan_result, plan_usage = await o.planner_agent.plan_chapter_scenes(
+            o.plot_outline,
+            novel_chapter_number,
+            plot_point_focus,
+            plot_point_index,
+            (novel_chapter_number - 1) % settings.PLOT_POINT_CHAPTER_SPAN + 1,
+            planning_context,
+            list(o.completed_plot_points),
+        )
+        o._accumulate_tokens(
+            f"Ch{novel_chapter_number}-{Stage.CHAPTER_PLANNING.value}", plan_usage
+        )
+
+        chapter_plan: list[SceneDetail] | None = chapter_plan_result
+
+        if (
+            settings.ENABLE_SCENE_PLAN_VALIDATION
+            and chapter_plan is not None
+            and settings.ENABLE_WORLD_CONTINUITY_CHECK
+        ):
+            (
+                plan_problems,
+                usage,
+            ) = await o.evaluator_agent.check_scene_plan_consistency(
+                o.plot_outline,
+                chapter_plan,
+                novel_chapter_number,
+                planning_context,
+            )
+            o._accumulate_tokens(
+                f"Ch{novel_chapter_number}-{Stage.PLAN_CONSISTENCY.value}", usage
+            )
+            await o.output_service.save_debug_output(
+                novel_chapter_number,
+                "scene_plan_consistency_problems",
+                plan_problems,
+            )
+            if plan_problems:
+                logger.warning(
+                    "NANA: Ch %s scene plan has %s consistency issues.",
+                    novel_chapter_number,
+                    len(plan_problems),
+                )
+
+        o.missing_references["characters"].clear()
+        o.missing_references["locations"].clear()
+        prev_state = await o._load_previous_end_state(novel_chapter_number - 1)
+        if chapter_plan and prev_state is not None:
+            known_chars = {c.name for c in prev_state.character_states}
+            known_locs = {c.location for c in prev_state.character_states}
+            known_locs.update(prev_state.key_world_changes.keys())
+            for scene in chapter_plan:
+                for name in scene.get("characters_involved", []):
+                    if name not in known_chars:
+                        o.missing_references["characters"].add(name)
+                setting = scene.get("setting_details")
+                if setting and setting not in known_locs:
+                    o.missing_references["locations"].add(setting)
+
+        hybrid_context_for_draft = o.next_chapter_context
+        if hybrid_context_for_draft is None:
+            await o.refresh_plot_outline()
+            if neo4j_manager.driver is not None:
+                await o.refresh_knowledge_cache()
+            else:
+                logger.warning(
+                    "Neo4j driver not initialized. Skipping knowledge cache refresh."
+                )
+            hybrid_context_for_draft = await o.context_service.build_hybrid_context(
+                o,
+                novel_chapter_number,
+                chapter_plan,
+                None,
+                profile_name=ContextProfileName.DEFAULT,
+                missing_entities=list(
+                    o.missing_references["characters"]
+                    | o.missing_references["locations"]
+                ),
+            )
+        else:
+            o.next_chapter_context = None
+
+        fill_in_lines = [
+            chunk.text for chunk in o.context_service.llm_fill_chunks if chunk.text
+        ]
+        if o.pending_fill_ins:
+            fill_in_lines = o.pending_fill_ins + fill_in_lines
+            o.pending_fill_ins = []
+        fill_in_context = "\n".join(fill_in_lines) or None
+
+        if settings.ENABLE_AGENTIC_PLANNING and chapter_plan is None:
+            logger.warning(
+                "NANA: Ch %s: Planning Agent failed or plan invalid. Proceeding with plot point focus only.",
+                novel_chapter_number,
+            )
+        await o.output_service.save_debug_output(
+            novel_chapter_number,
+            "scene_plan",
+            chapter_plan if chapter_plan else "No plan generated.",
+        )
+        await o.output_service.save_debug_output(
+            novel_chapter_number,
+            "hybrid_context_for_draft",
+            hybrid_context_for_draft,
+        )
+
+        return PrerequisiteData(
+            plot_point_focus=plot_point_focus,
+            plot_point_index=plot_point_index,
+            chapter_plan=chapter_plan,
+            hybrid_context_for_draft=hybrid_context_for_draft,
+            fill_in_context=fill_in_context,
+        )


### PR DESCRIPTION
## Summary
- split rich output saving into new `OutputService`
- extract prerequisite gathering into `PrerequisiteService`
- use both services inside `NANA_Orchestrator`

## Testing
- `ruff format orchestration/nana_orchestrator.py orchestration/output_service.py orchestration/prerequisite_service.py`
- `ruff check orchestration/nana_orchestrator.py orchestration/output_service.py orchestration/prerequisite_service.py`
- `mypy orchestration/nana_orchestrator.py orchestration/output_service.py orchestration/prerequisite_service.py` *(fails: many missing stubs)*
- `pytest -v --cov=. --cov-report=term-missing` *(fails: pytest-cov not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686800be3228832fa1fb790b76404698