### PR TITLE
Add complexity analysis utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ novel_output/
 
 # OS files
 .DS_Store
+.venv/

--- a/README.md
+++ b/README.md
@@ -237,6 +237,16 @@ To start SAGA from a completely fresh state:
 
 After resetting and ensuring Neo4j is running, the next execution of `python main.py` will re-initialize the story and KG.
 
+## Complexity Analysis
+
+You can check SAGA's cyclomatic complexity with [Radon](https://radon.readthedocs.io/en/latest/):
+
+```bash
+python complexity_report.py
+```
+
+This runs `radon cc . -nc` and highlights functions that may benefit from refactoring.
+
 ## License
 
 This project is licensed under the Apache License, Version 2.0. See the `LICENSE` file for details.

--- a/complexity_report.py
+++ b/complexity_report.py
@@ -1,0 +1,20 @@
+import subprocess
+from typing import Sequence
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+
+def run_complexity(extra_args: Sequence[str] | None = None) -> int:
+    """Run radon cyclomatic complexity analysis."""
+    command = ["radon", "cc", ".", "-nc"]
+    if extra_args:
+        command.extend(extra_args)
+    logger.info("running complexity analysis", command=" ".join(command))
+    result = subprocess.run(command)
+    return result.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(run_complexity())

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ ollama==0.2.0
 python-dotenv==1.1.0
 PyYAML==6.0.2
 pydantic>=2.11,<3
-pydantic-settings
+pydantic-settings>=2,<3
 rdflib==7.0.0
 rich==14.0.0
 spacy==3.8.7
@@ -17,9 +17,12 @@ tiktoken==0.9.0
 jinja2>=3.1,<4
 rapidfuzz>=3.6,<4
 
+# Tooling
+radon>=6,<7
+
 
 # Development & Testing Dependencies
 flake8==7.0.0
 pytest==8.3.5
-pytest-cov
-pytest-asyncio
+pytest-cov>=4,<7
+pytest-asyncio>=0.23,<2


### PR DESCRIPTION
## Summary
- ignore `.venv` in git
- add Radon to requirements
- create `complexity_report.py` helper
- document how to run complexity checks
- pin versions for all dependencies

## Testing
- `ruff check .`
- `ruff format --check .`
- `pytest tests/ -v` *(fails: ModuleNotFoundError: async_lru, numpy, yaml, structlog)*
- `mypy .` *(fails: Cannot find library stubs for many modules)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_686803304c20832fb995397a875deb57