### PR TITLE
[DATA_ACCESS] Refactor world sync

### DIFF
--- a/complexity_report.py
+++ b/complexity_report.py
@@ -1,5 +1,5 @@
 import subprocess
-from typing import Sequence
+from collections.abc import Sequence
 
 import structlog
 


### PR DESCRIPTION
## Summary
- break up `sync_full_state_from_object_to_db` into helper functions
- add utility to build world element IDs and statements
- update complexity report import per ruff

## Testing
- `ruff check .`
- `mypy .` *(fails: Library stubs not installed for "yaml" and many other errors)*
- `pytest -v --cov=. --cov-report=term-missing` *(fails: 10 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68680c50aca8832f9477bda64770bf1c