### PR TITLE
[CORE] reduce complexity in bootstrappers and plot persistence

### DIFF
--- a/initialization/bootstrappers/plot_bootstrapper.py
+++ b/initialization/bootstrappers/plot_bootstrapper.py
@@ -1,5 +1,7 @@
+# initialization/bootstrappers/plot_bootstrapper.py
 import asyncio
 from collections.abc import Coroutine
+from typing import Any
 
 import structlog
 import utils
@@ -8,6 +10,94 @@ from config import settings
 from initialization.models import PlotOutline
 
 from .common import bootstrap_field
+
+
+def _needs_bootstrap(value: Any) -> bool:
+    """Return ``True`` if ``value`` is empty or a fill-in marker."""
+    return not value or utils._is_fill_in(value)
+
+
+def _fields_to_bootstrap(plot_outline: PlotOutline) -> dict[str, bool]:
+    """Return mapping of plot fields that require bootstrapping."""
+    return {
+        "title": _needs_bootstrap(plot_outline.get("title")),
+        "protagonist_name": _needs_bootstrap(plot_outline.get("protagonist_name")),
+        "genre": _needs_bootstrap(plot_outline.get("genre")),
+        "setting": _needs_bootstrap(plot_outline.get("setting")),
+        "theme": _needs_bootstrap(plot_outline.get("theme")),
+        "logline": _needs_bootstrap(plot_outline.get("logline")),
+        "inciting_incident": _needs_bootstrap(plot_outline.get("inciting_incident")),
+        "central_conflict": _needs_bootstrap(plot_outline.get("central_conflict")),
+        "stakes": _needs_bootstrap(plot_outline.get("stakes")),
+        "narrative_style": _needs_bootstrap(plot_outline.get("narrative_style")),
+        "tone": _needs_bootstrap(plot_outline.get("tone")),
+        "pacing": _needs_bootstrap(plot_outline.get("pacing")),
+    }
+
+
+def _calculate_needed_plot_points(points: list[str]) -> int:
+    """Return count of plot points that must be generated."""
+    fill_in_count = sum(1 for p in points if utils._is_fill_in(p))
+    return max(
+        0,
+        settings.TARGET_PLOT_POINTS_INITIAL_GENERATION - (len(points) - fill_in_count),
+    )
+
+
+def _build_bootstrap_tasks(plot_outline: PlotOutline) -> dict[str, Coroutine]:
+    """Return mapping of field names to bootstrap tasks."""
+    tasks: dict[str, Coroutine] = {}
+    for field, needed in _fields_to_bootstrap(plot_outline).items():
+        if needed:
+            tasks[field] = bootstrap_field(
+                field,
+                plot_outline,
+                "bootstrapper/fill_plot_field.j2",
+            )
+
+    needed_plot_points = _calculate_needed_plot_points(
+        plot_outline.get("plot_points", []) or []
+    )
+    if needed_plot_points > 0:
+        tasks["plot_points"] = bootstrap_field(
+            "plot_points",
+            plot_outline,
+            "bootstrapper/fill_plot_points.j2",
+            is_list=True,
+            list_count=needed_plot_points,
+        )
+    return tasks
+
+
+def _apply_bootstrap_results(
+    plot_outline: PlotOutline,
+    results: list[tuple[Any, dict[str, int] | None]],
+    keys: list[str],
+    usage_data: dict[str, int],
+) -> None:
+    """Merge bootstrap results back into ``plot_outline`` and ``usage_data``."""
+    for i, (value, usage) in enumerate(results):
+        field = keys[i]
+        if usage:
+            for k, v in usage.items():
+                usage_data[k] = usage_data.get(k, 0) + v
+        if field == "plot_points":
+            final_points = [
+                p
+                for p in plot_outline.get("plot_points", [])
+                if not utils._is_fill_in(p)
+            ]
+            final_points.extend(value)
+            plot_outline["plot_points"] = final_points[
+                : settings.TARGET_PLOT_POINTS_INITIAL_GENERATION
+            ]
+        elif value:
+            plot_outline[field] = value
+
+    if usage_data["total_tokens"] > 0:
+        plot_outline["is_default"] = False
+        plot_outline["source"] = "bootstrapped"
+
 
 logger = structlog.get_logger(__name__)
 
@@ -38,89 +128,11 @@ async def bootstrap_plot_outline(
     plot_outline: PlotOutline,
 ) -> tuple[PlotOutline, dict[str, int] | None]:
     """Fill missing plot fields via LLM."""
-    tasks: dict[str, Coroutine] = {}
-    usage_data: dict[str, int] = {
-        "prompt_tokens": 0,
-        "completion_tokens": 0,
-        "total_tokens": 0,
-    }
-
-    fields_to_bootstrap = {
-        "title": not plot_outline.get("title")
-        or utils._is_fill_in(plot_outline.get("title")),
-        "protagonist_name": not plot_outline.get("protagonist_name")
-        or utils._is_fill_in(plot_outline.get("protagonist_name")),
-        "genre": not plot_outline.get("genre")
-        or utils._is_fill_in(plot_outline.get("genre")),
-        "setting": not plot_outline.get("setting")
-        or utils._is_fill_in(plot_outline.get("setting")),
-        "theme": not plot_outline.get("theme")
-        or utils._is_fill_in(plot_outline.get("theme")),
-        "logline": not plot_outline.get("logline")
-        or utils._is_fill_in(plot_outline.get("logline")),
-        "inciting_incident": not plot_outline.get("inciting_incident")
-        or utils._is_fill_in(plot_outline.get("inciting_incident")),
-        "central_conflict": not plot_outline.get("central_conflict")
-        or utils._is_fill_in(plot_outline.get("central_conflict")),
-        "stakes": not plot_outline.get("stakes")
-        or utils._is_fill_in(plot_outline.get("stakes")),
-        "narrative_style": not plot_outline.get("narrative_style")
-        or utils._is_fill_in(plot_outline.get("narrative_style")),
-        "tone": not plot_outline.get("tone")
-        or utils._is_fill_in(plot_outline.get("tone")),
-        "pacing": not plot_outline.get("pacing")
-        or utils._is_fill_in(plot_outline.get("pacing")),
-    }
-
-    for field, needed in fields_to_bootstrap.items():
-        if needed:
-            tasks[field] = bootstrap_field(
-                field, plot_outline, "bootstrapper/fill_plot_field.j2"
-            )
-
-    plot_points = plot_outline.get("plot_points", [])
-    fill_in_count = sum(1 for p in plot_points if utils._is_fill_in(p))
-    needed_plot_points = max(
-        0,
-        settings.TARGET_PLOT_POINTS_INITIAL_GENERATION
-        - (len(plot_points) - fill_in_count),
-    )
-
-    if needed_plot_points > 0:
-        tasks["plot_points"] = bootstrap_field(
-            "plot_points",
-            plot_outline,
-            "bootstrapper/fill_plot_points.j2",
-            is_list=True,
-            list_count=needed_plot_points,
-        )
-
+    tasks = _build_bootstrap_tasks(plot_outline)
     if not tasks:
         return plot_outline, None
 
+    usage_data = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
     results = await asyncio.gather(*tasks.values())
-    task_keys = list(tasks.keys())
-
-    for i, (value, usage) in enumerate(results):
-        field = task_keys[i]
-        if usage:
-            for k, v in usage.items():
-                usage_data[k] = usage_data.get(k, 0) + v
-        if field == "plot_points":
-            new_points = value
-            final_points = [
-                p
-                for p in plot_outline.get("plot_points", [])
-                if not utils._is_fill_in(p)
-            ]
-            final_points.extend(new_points)
-            plot_outline["plot_points"] = final_points[
-                : settings.TARGET_PLOT_POINTS_INITIAL_GENERATION
-            ]
-        elif value:
-            plot_outline[field] = value
-
-    if usage_data["total_tokens"] > 0:
-        plot_outline["is_default"] = False
-        plot_outline["source"] = "bootstrapped"
+    _apply_bootstrap_results(plot_outline, results, list(tasks.keys()), usage_data)
     return plot_outline, usage_data if usage_data["total_tokens"] > 0 else None


### PR DESCRIPTION
## Summary
- add helpers for plot bootstrapping
- refactor plot outline persistence helpers
- apply new helpers in bootstrap and save routines

## Testing
- `ruff check data_access/plot_queries.py`
- `ruff check initialization/bootstrappers/plot_bootstrapper.py`
- `mypy .` *(fails: Library stubs not installed for "yaml")*
- `pytest -v --cov=. --cov-report=term-missing` *(errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68683262fb14832f8681dabf77df5bbf