### PR TITLE
[CORE] fix ChapterEndState imports

### DIFF
--- a/kg_maintainer/models.py
+++ b/kg_maintainer/models.py
@@ -4,6 +4,7 @@
 from typing import TypedDict
 
 from models import (
+    ChapterEndState,
     CharacterProfile,
     EvaluationResult,
     PatchInstruction,
@@ -29,4 +30,5 @@ __all__ = [
     "ProblemDetail",
     "SceneDetail",
     "WorldItem",
+    "ChapterEndState",
 ]

--- a/orchestration/output_service.py
+++ b/orchestration/output_service.py
@@ -8,9 +8,9 @@ from typing import TYPE_CHECKING, Any
 import structlog
 from agents.finalize_agent import FinalizationResult
 from data_access import character_queries, world_queries
-from kg_maintainer.models import ChapterEndState
 from storage.file_manager import FileManager
 
+from models import ChapterEndState
 from orchestration.token_accountant import Stage
 
 if TYPE_CHECKING:  # pragma: no cover - type hints


### PR DESCRIPTION
## Summary
- export `ChapterEndState` in `kg_maintainer.models`
- update `OutputService` to import from `models`

## Testing
- `ruff check .`
- `ruff format --diff --quiet kg_maintainer/models.py orchestration/output_service.py`
- `mypy .` *(fails: Function is missing a return type annotation, etc.)*
- `pytest -v --cov=. --cov-report=term-missing` *(fails: 2 failed, 64 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686848bc1c14832fbffd610863693a71