### PR TITLE
[DOC] Add setup script for installing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,9 @@ source venv/bin/activate  # On Windows: venv\Scripts\activate
 pip install -r requirements.txt
 python -m spacy download en_core_web_sm
 ```
+Alternatively, run `./setup.sh` to automate these steps. The `requirements.txt`
+file already lists packages such as `numpy`, `structlog`, and `PyYAML`, ensuring
+that `pytest` can run without import errors.
 
 ### 3. Configure SAGA
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,12 @@
+# setup.sh
+# Root-level script to set up the Python environment
+
+set -euo pipefail
+
+python -m venv venv
+source venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+pip install ruff mypy pytest-cov
+
+echo "Environment ready. Activate with: source venv/bin/activate"


### PR DESCRIPTION
## Summary
- document that `numpy`, `structlog`, and `PyYAML` are in requirements
- provide `setup.sh` to create a virtual environment and install dependencies

## Testing
- `ruff check .` *(fails: UP038)*
- `ruff format .`
- `mypy .` *(fails: found 603 errors)*
- `pytest -v --cov=. --cov-report=term-missing` *(fails: 15 failed, 80 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686a9a33e0f4832fb503e81dea844569