### PR TITLE
[CORE] fix list attribute populate

### DIFF
--- a/data_access/cypher_builders/world_cypher.py
+++ b/data_access/cypher_builders/world_cypher.py
@@ -72,9 +72,9 @@ def _prepare_node_properties(
             ):
                 continue
 
-            if isinstance(value, (str, int, float, bool)):
+            if isinstance(value, str | int | float | bool):
                 node_props[key] = value
-            elif isinstance(value, (list, dict)):
+            elif isinstance(value, list | dict):
                 try:
                     node_props[key] = json.dumps(value, ensure_ascii=False)
                 except TypeError:

--- a/data_access/services/world_persistence_service.py
+++ b/data_access/services/world_persistence_service.py
@@ -156,7 +156,7 @@ class WorldPersistenceService:
             == "provisional_from_unrevised_draft",
         }
         for key, val in overview_details.items():
-            if isinstance(val, (str, int, float, bool)) and key not in wc_props:
+            if isinstance(val, str | int | float | bool) and key not in wc_props:
                 wc_props[key] = val
         return [
             (
@@ -214,7 +214,7 @@ class WorldPersistenceService:
 
         for key, val in details.items():
             if (
-                isinstance(val, (str, int, float, bool))
+                isinstance(val, str | int | float | bool)
                 and key not in we_props  # Avoid overwriting already set core properties
                 and not key.startswith(kg_keys.ELABORATION_PREFIX)
                 and not key.startswith(kg_keys.ADDED_PREFIX)

--- a/data_access/utils/world_utils.py
+++ b/data_access/utils/world_utils.py
@@ -179,7 +179,10 @@ def populate_list_attributes_for_item(
     list_attrs = ["goals", "rules", "key_elements", "traits"]
     for attr in list_attrs:
         # Ensure values are strings and filter out None before sorting
-        attr_values = [str(v) for v in record.get(attr, []) if v is not None]
+        values = record.get(attr)
+        if not values:
+            values = []
+        attr_values = [str(v) for v in values if v is not None]
         item_detail_dict[attr] = sorted(attr_values)
 
 


### PR DESCRIPTION
## Summary
- fix TypeError in world_utils.populate_list_attributes_for_item
- adapt isinstance checks to use union types

## Agent Modifications
- None

## Database or Config Updates
- None

## Testing Performed
- `ruff check . && ruff format .`
- `mypy .` *(fails: missing stubs and annotations)*
- `pytest -v --cov=. --cov-report=term-missing` *(fails: multiple test failures)*

## Performance Considerations
- None

------
https://chatgpt.com/codex/tasks/task_e_686a9bd6caac832faff2aaa76596ceb2