### PR TITLE
[ORCHESTRATION] Replace False type hint block

### DIFF
--- a/orchestration/chapter_generation_runner.py
+++ b/orchestration/chapter_generation_runner.py
@@ -1,8 +1,10 @@
+# orchestration/chapter_generation_runner.py
 from __future__ import annotations
 
 # pragma: no cover
 from dataclasses import dataclass
 from enum import Enum, auto
+from typing import TYPE_CHECKING
 
 import structlog
 from config import settings
@@ -10,7 +12,7 @@ from core.db_manager import neo4j_manager
 
 import utils
 
-if False:  # pragma: no cover - type hints
+if TYPE_CHECKING:  # pragma: no cover - type hints
     from .nana_orchestrator import NANA_Orchestrator
 
 logger = structlog.get_logger(__name__)


### PR DESCRIPTION
## Summary
- use TYPE_CHECKING for chapter generation runner

## Testing
- `ruff check orchestration/chapter_generation_runner.py`
- `mypy .` *(fails: missing stubs and type errors)*
- `pytest -v --cov=. --cov-report=term-missing` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_686aaf520b04832fab95ceb2710e04d6