### PR TITLE
[CONFIG] add secret validation

### DIFF
--- a/config.py
+++ b/config.py
@@ -314,6 +314,19 @@ class SagaSettings(BaseSettings):
             self.PATCH_GENERATION_MODEL = self.MEDIUM_MODEL
         return self
 
+    @model_validator(mode="after")
+    def validate_secret_values(self) -> SagaSettings:
+        """Ensure sensitive settings are not left as default placeholders."""
+        if self.OPENAI_API_KEY == "nope":
+            raise ValueError(
+                "OPENAI_API_KEY must be set to a real value instead of the default 'nope'."
+            )
+        if self.NEO4J_PASSWORD == "saga_password":
+            logger.warning(
+                "NEO4J_PASSWORD appears to be using the default placeholder value."
+            )
+        return self
+
     model_config = SettingsConfigDict(env_prefix="", env_file=".env")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+# tests/conftest.py
 import os
 import sys
 
@@ -5,3 +6,7 @@ import sys
 repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
 if repo_root not in sys.path:
     sys.path.insert(0, repo_root)
+
+# Ensure placeholder secrets do not trigger validators during tests
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+os.environ.setdefault("NEO4J_PASSWORD", "test-password")

--- a/tests/test_config_validators.py
+++ b/tests/test_config_validators.py
@@ -1,0 +1,21 @@
+# tests/test_config_validators.py
+
+import config
+import pytest
+from config import SagaSettings
+
+
+def test_openai_key_placeholder_raises():
+    with pytest.raises(ValueError):
+        SagaSettings(OPENAI_API_KEY="nope")
+
+
+def test_default_neo4j_password_warns(monkeypatch):
+    warnings: list[str] = []
+
+    def fake_warning(msg: str, **_kw: object) -> None:
+        warnings.append(msg)
+
+    monkeypatch.setattr(config.logger, "warning", fake_warning)
+    SagaSettings(OPENAI_API_KEY="valid", NEO4J_PASSWORD="saga_password")
+    assert any("NEO4J_PASSWORD" in msg for msg in warnings)


### PR DESCRIPTION
## Summary
- validate `OPENAI_API_KEY` and `NEO4J_PASSWORD` in `SagaSettings`
- inject test secrets in `conftest`
- add regression tests for the new validation logic

## Agent Updates
- `SagaSettings` now raises `ValueError` for default `OPENAI_API_KEY` and logs a warning for default `NEO4J_PASSWORD`.

## Configuration
- no new config files

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mypy .` *(fails: missing stubs and numerous typing issues)*
- `pytest -v --cov=. --cov-report=term-missing` *(fails: 14 failed, 87 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686af4d1cf54832f97771f85a768bf89