### PR TITLE
[AGENTS] Refactor planner JSON loading

### DIFF
--- a/tests/test_planner_agent_json_plan.py
+++ b/tests/test_planner_agent_json_plan.py
@@ -1,0 +1,30 @@
+# tests/test_planner_agent_json_plan.py
+from agents.planner_agent import PlannerAgent
+
+
+def test_load_json_plan_valid():
+    agent = PlannerAgent()
+    data = agent._load_json_plan('[{"scene_number": 1, "summary": "s"}]', 1)
+    assert data == [{"scene_number": 1, "summary": "s"}]
+
+
+def test_load_json_plan_fallback():
+    agent = PlannerAgent()
+    text = 'garbage [{"scene_number": 1, "summary": "s"}] trailing'
+    data = agent._load_json_plan(text, 1)
+    assert data == [{"scene_number": 1, "summary": "s"}]
+
+
+def test_load_json_plan_invalid():
+    agent = PlannerAgent()
+    assert agent._load_json_plan("invalid", 1) is None
+
+
+def test_load_json_plan_non_list():
+    agent = PlannerAgent()
+    assert agent._load_json_plan('{"a": 1}', 1) is None
+
+
+def test_load_json_plan_empty_list():
+    agent = PlannerAgent()
+    assert agent._load_json_plan("[]", 1) is None


### PR DESCRIPTION
## Summary
- refactor `_load_json_plan` to use smaller helpers
- add unit tests for valid/invalid JSON planning cases

## Agent Modifications
- `planner_agent.py` uses `_parse_json_with_fallback` and `_validate_scene_plan_data` helpers

## Database or Config Updates
- none

## Testing Performed
- `ruff check .`
- `ruff format .`
- `mypy .` *(fails: 92 errors)*
- `pytest -v --cov=. --cov-report=term-missing` *(fails: 14 failed, 87 passed)*

## Performance Considerations
- no impact


------
https://chatgpt.com/codex/tasks/task_e_686af9a97994832f9dba3306c4925eca