### PR TITLE
[UTILS] Raise error on non-YAML path

### DIFF
--- a/tests/test_yaml_parser.py
+++ b/tests/test_yaml_parser.py
@@ -69,6 +69,10 @@ class TestYamlParsing(unittest.TestCase):
         data = load_yaml_file("non_existent.yaml")
         self.assertIsNone(data)
 
+    def test_load_non_yaml_file(self):
+        with self.assertRaises(ValueError):
+            load_yaml_file("not_yaml.txt")
+
     def test_load_malformed_yaml(self):
         data = load_yaml_file(self.malformed_yaml_filepath)
         self.assertIsNone(data)

--- a/yaml_parser.py
+++ b/yaml_parser.py
@@ -40,8 +40,7 @@ def load_yaml_file(filepath: str, normalize_keys: bool = True) -> dict[str, Any]
         A dictionary representing the YAML content, or None if an error occurs.
     """
     if not filepath.endswith((".yaml", ".yml")):
-        logger.error(f"File specified is not a YAML file: {filepath}")
-        return None
+        raise ValueError(f"File specified is not a YAML file: {filepath}")
     try:
         with open(filepath, encoding="utf-8") as f:
             content = yaml.safe_load(f)


### PR DESCRIPTION
## Summary
- raise `ValueError` in `load_yaml_file` for invalid extensions
- test new behavior in `tests/test_yaml_parser.py`

## Agent Modifications
- none

## Database or Config Updates
- none

## Testing Performed
- `ruff check yaml_parser.py tests/test_yaml_parser.py`
- `mypy yaml_parser.py tests/test_yaml_parser.py`
- `pytest -v --cov=. --cov-report=term-missing tests/test_yaml_parser.py`

## Performance Considerations
- negligible impact

------
https://chatgpt.com/codex/tasks/task_e_686aff8cb510832fa3dc4e6e70812ad8