### PR TITLE
[CONFIG] Pin mypy and pydantic versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ openai==1.30.1
 ollama==0.2.0
 python-dotenv==1.1.0
 PyYAML==6.0.2
-pydantic>=2.11,<3
+pydantic==2.11.7
 pydantic-settings>=2,<3
 rdflib==7.0.0
 rich==14.0.0
@@ -26,4 +26,6 @@ flake8==7.0.0
 pytest==8.3.5
 pytest-cov>=4,<7
 pytest-asyncio>=0.23,<2
+types-PyYAML
+mypy==1.16.1
 


### PR DESCRIPTION
## Summary
- add types-PyYAML stub package
- pin pydantic to 2.11.7 and mypy to 1.16.1

## Agent Modifications
- none

## Database or Config Updates
- requirements updated to ensure compatibility between mypy and pydantic

## Testing Performed
- `ruff check .`
- `ruff format .`
- `mypy .`
- `pytest -v --cov=. --cov-report=term-missing` *(fails: 14 failed, 89 passed)*

## Performance Considerations
- N/A

------
https://chatgpt.com/codex/tasks/task_e_686b18d57f90832f998615f9c7559eec