### PR TITLE
Improve data access efficiency

### DIFF
--- a/config.py
+++ b/config.py
@@ -181,6 +181,8 @@ class SagaSettings(BaseSettings):
     SUMMARY_CACHE_SIZE: int = 32
     KG_TRIPLE_EXTRACTION_CACHE_SIZE: int = 16
     TOKENIZER_CACHE_SIZE: int = 10
+    SCENE_CACHE_SIZE: int = 32
+    WORLD_QUERY_BATCH_SIZE: int = 100
 
     # Reranking Configuration
     ENABLE_RERANKING: bool = False


### PR DESCRIPTION
## Summary
- batch world graph retrieval to limit memory use
- cache scene generation for reuse across calls
- expose new cache and batch settings
- test scene caching behavior

## Testing
- `ruff check . && ruff format --check .`
- `pytest tests/test_drafting_agent.py::test_draft_chapter_caching -v`
- `pytest tests/ -v --cov=. --cov-report=term-missing` *(failed: Killed)*
- `mypy .` *(failed: 31 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687862405900832f9f4e4cc77e552a01