### PR TITLE
Fix Neo4j UUID parameter handling

### DIFF
--- a/tests/test_db_manager_uuid.py
+++ b/tests/test_db_manager_uuid.py
@@ -1,0 +1,13 @@
+import uuid
+from core.db_manager import Neo4jManagerSingleton
+
+
+def test_sanitize_parameters_uuid():
+    manager = Neo4jManagerSingleton()
+    uid = uuid.uuid4()
+    params = {"id": uid, "nested": {"inner": uid}, "list": [uid, 1]}
+    sanitized = manager._sanitize_parameters(params)
+    assert isinstance(sanitized["id"], str)
+    assert isinstance(sanitized["nested"]["inner"], str)
+    assert isinstance(sanitized["list"][0], str)
+    assert sanitized["list"][1] == 1


### PR DESCRIPTION
## Summary
- sanitize Cypher parameters for unsupported types
- ensure UUIDs are converted to strings before sending to Neo4j
- test sanitization helper

## Testing
- `ruff check . && ruff format --check .`
- `pytest tests/ -v --cov=. --cov-report=term-missing`
- `mypy .` *(fails: library stubs missing and config issues)*

------
https://chatgpt.com/codex/tasks/task_e_687a6f3f322c832f84a28459e2382883