### PR TITLE
Use shared schema introspector instance

### DIFF
--- a/core/schema_introspector.py
+++ b/core/schema_introspector.py
@@ -24,10 +24,14 @@ logger = logging.getLogger(__name__)
 class SchemaIntrospector:
     """Dynamic schema discovery using Neo4j built-in introspection procedures."""
 
+    _cache_service_registered = False
+
     def __init__(self):
         self._service_name = "schema_introspection"
-        # Register with cache coordinator
-        register_cache_service(self._service_name)
+        # Register with cache coordinator only once
+        if not SchemaIntrospector._cache_service_registered:
+            register_cache_service(self._service_name)
+            SchemaIntrospector._cache_service_registered = True
         self.cache_ttl = 300  # 5 minutes cache
         self.last_schema_update = None
 

--- a/core/triple_processor.py
+++ b/core/triple_processor.py
@@ -206,9 +206,8 @@ class TripleProcessor:
             or self._type_inference_service is None
         ):
             from core.intelligent_type_inference import IntelligentTypeInference
-            from core.schema_introspector import SchemaIntrospector
+            from core.schema_introspector import schema_introspector
 
-            schema_introspector = SchemaIntrospector()
             self._type_inference_service = IntelligentTypeInference(schema_introspector)
             logger.debug(
                 "Type inference service created directly for static deployment"


### PR DESCRIPTION
## Summary
- reuse the module-level `schema_introspector` when building the triple processor's type inference service
- guard `SchemaIntrospector` cache registration so it only occurs once even if multiple instances are created

## Testing
- `pytest` *(fails: existing SyntaxError in data_access/chapter_queries.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c88e83f748832fa32d3ce0c66d540b