### PR TITLE
feat(core): enhance LLM fallback handling and content extraction

### DIFF
--- a/initialization/bootstrappers/common.py
+++ b/initialization/bootstrappers/common.py
@@ -20,6 +20,13 @@ async def bootstrap_field(
 ) -> tuple[Any, dict[str, int] | None]:
     """Call LLM to fill a single field or list of fields."""
     logger.info(f"Bootstrapping field: '{field_name}'...")
+    # Provide safe defaults expected by some templates to avoid StrictUndefined errors
+    if prompt_template_path.endswith("bootstrapper/fill_world_item_field.j2"):
+        context_data = dict(context_data)  # do not mutate caller data
+        context_data.setdefault("existing_world_names", [])
+        context_data.setdefault("retry_attempt", 0)
+        context_data.setdefault("diversity_instruction", "")
+
     prompt = render_prompt(
         prompt_template_path,
         {"context": context_data, "field_name": field_name, "list_count": list_count},

--- a/tests/test_kg_relationship_growth.py
+++ b/tests/test_kg_relationship_growth.py
@@ -1,0 +1,60 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from data_access import kg_queries
+
+
+@pytest.mark.asyncio
+async def test_relationships_are_unique_per_chapter(monkeypatch):
+    """Ensure the same triple across chapters produces distinct relationships.
+
+    This guards against MERGE flattening that would overwrite prior edges and
+    cause the visible KG to appear to stagnate or shrink across chapters.
+    """
+
+    captured_batches = []
+
+    async def fake_execute_cypher_batch(statements):  # type: ignore[override]
+        captured_batches.append(statements)
+
+    monkeypatch.setattr(
+        kg_queries.neo4j_manager,
+        "execute_cypher_batch",
+        AsyncMock(side_effect=fake_execute_cypher_batch),
+    )
+
+    triple = {
+        "subject": {"name": "Elara", "type": "Character"},
+        "predicate": "LOCATED_IN",
+        "object_entity": {"name": "Sunken Library", "type": "Location"},
+        "is_literal_object": False,
+    }
+
+    # Add for chapter 1 and 2
+    await kg_queries.add_kg_triples_batch_to_db(
+        [triple], chapter_number=1, is_from_flawed_draft=False
+    )
+    await kg_queries.add_kg_triples_batch_to_db(
+        [triple], chapter_number=2, is_from_flawed_draft=False
+    )
+
+    # We expect two batches (one per call)
+    assert len(captured_batches) == 2
+
+    def extract_rel_ids(batch):
+        ids = []
+        for query, params in batch:
+            if "MERGE (s)-[r:`LOCATED_IN` {id: $rel_id_param}]->(o)" in query:
+                ids.append(params.get("rel_id_param"))
+        return ids
+
+    rel_ids_ch1 = extract_rel_ids(captured_batches[0])
+    rel_ids_ch2 = extract_rel_ids(captured_batches[1])
+
+    # Ensure we created one LOCATED_IN relationship per batch with an id
+    assert len(rel_ids_ch1) == 1 and rel_ids_ch1[0]
+    assert len(rel_ids_ch2) == 1 and rel_ids_ch2[0]
+
+    # Critical: they must be different across chapters
+    assert rel_ids_ch1[0] != rel_ids_ch2[0]

--- a/tests/test_llm_interface_content_extraction.py
+++ b/tests/test_llm_interface_content_extraction.py
@@ -1,0 +1,74 @@
+import pytest
+
+from core.llm_interface_refactored import CompletionService
+
+
+class _DummyCompletionClient:
+    def __init__(self):
+        self.called = False
+
+    async def get_completion(self, *args, **kwargs):
+        self.called = True
+        # Simulate provider that returns reasoning_content instead of content
+        return {
+            "id": "chatcmpl-test",
+            "object": "chat.completion",
+            "created": 0,
+            "model": "qwen3-4b",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "reasoning_content": "Reasoned output JSON",
+                    },
+                    "finish_reason": "length",
+                }
+            ],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3},
+        }
+
+    async def get_streaming_completion(self, *args, **kwargs):
+        # Yield two chunks that stream reasoning_content in the delta
+        async def _gen():
+            yield {
+                "choices": [
+                    {"delta": {"reasoning_content": "Hello "}, "finish_reason": None}
+                ]
+            }
+            yield {
+                "choices": [
+                    {"delta": {"reasoning_content": "World"}, "finish_reason": None}
+                ]
+            }
+
+        # Make this an async generator function by yielding from the inner generator
+        async for item in _gen():
+            yield item
+
+
+class _DummyTextProcessor:
+    class _Cleaner:
+        def clean_response(self, text: str) -> str:
+            return text.strip()
+
+    def __init__(self):
+        self.response_cleaner = self._Cleaner()
+
+    def get_combined_statistics(self):
+        return {}
+
+
+@pytest.mark.asyncio
+async def test_extracts_reasoning_content_when_missing_content():
+    svc = CompletionService(_DummyCompletionClient(), _DummyTextProcessor())
+    text, usage = await svc.get_completion("model", "prompt")
+    assert text == "Reasoned output JSON"
+    assert usage and usage.get("total_tokens") == 3
+
+
+@pytest.mark.asyncio
+async def test_streaming_delta_reasoning_content_accumulates():
+    svc = CompletionService(_DummyCompletionClient(), _DummyTextProcessor())
+    text, usage = await svc.get_streaming_completion("model", "prompt")
+    assert text == "Hello World"


### PR DESCRIPTION
- Replace FALLBACK_GENERATION_MODEL with MEDIUM_MODEL for fallback logic
- Improve streaming content extraction to handle 'reasoning_content' field
- Add robust content extraction with multiple fallback strategies:
  * Standard message.content
  * reasoning_content for Qwen models
  * Direct choice content
 * Top-level convenience fields (output_text, text, response, content)
- Add error handling and logging for content extraction failures
- Create stable relationship IDs in KG queries to prevent history flattening